### PR TITLE
Fix inline assign and access

### DIFF
--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithInlineAssignFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithInlineAssignFixture.php
@@ -9,3 +9,10 @@ function function_with_inline_assigns() {
     }
     echo $var2;
 }
+
+function function_with_assigns_and_usage() {
+    doSomething(
+        $foo = 'bar',
+        $foo
+    );
+}


### PR DESCRIPTION
Fixes #13

When a variable is found, we use `findWhereAssignExecuted()` to consider where to mark that variable as "ready to be used" (eg: this is illegal if `$foo` is not defined: `$foo = $foo + 1;`). It checks for semicolons or closing parenthesis and returns whichever comes first.

In this case, the expression `($foo = 1, $foo)` uses the variable before either a semicolon or a parenthesis; instead it uses a comma.

This PR adds `T_COMMA` as a possible ending token as well.