### PR TITLE
Allow unused function arguments as regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,24 @@ If you already have installed paths, [use a comma to separate them](https://gith
 
 ## Customization
 
-There's a variety of options to customize the behaviour of VariableAnalysis, take
-a look at the included ruleset.xml.example for commented examples of a configuration.
+There's a variety of options to customize the behaviour of VariableAnalysis, take a look at the included ruleset.xml.example for commented examples of a configuration.
+
+The available options are as follows:
+
+- `allowUnusedFunctionParameters` (bool, default `false`): if set to true, function arguments will never be marked as unused.
+- `allowUnusedCaughtExceptions` (bool, default `false`): if set to true, caught Exception variables will never be marked as unused.
+- `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
+- `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.
+
+To set these these options, you must use XML in your ruleset. For details, see the [phpcs customizable sniff properties page](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties). Here is an example that ignores all variables that start with an underscore:
+
+```xml
+<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+    <properties>
+        <property name="ignoreUnusedRegexp" value="/^_/"/>
+    </properties>
+</rule>
+```
 
 ## Original
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -41,8 +41,9 @@ class VariableAnalysisSniff implements Sniff {
   public $allowUnusedFunctionParameters = false;
 
   /**
-   *  A list of names of placeholder variables that you want to ignore from
-   *  unused variable warnings, ie things like $junk.
+   *  A space-separated list of names of placeholder variables that you want to
+   *  ignore from unused variable warnings. For example, to ignore the variables
+   *  `$junk` and `$unused`, this could be set to `'junk unused'`.
    */
   public $validUnusedVariableNames = null;
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -48,10 +48,6 @@ class VariableAnalysisSniff implements Sniff {
   public $validUnusedVariableNames = null;
 
   public function register() {
-    if (!empty($this->validUnusedVariableNames)) {
-      $this->validUnusedVariableNames =
-        preg_split('/\s+/', trim($this->validUnusedVariableNames));
-    }
     return [
       T_VARIABLE,
       T_DOUBLE_QUOTED_STRING,
@@ -124,7 +120,10 @@ class VariableAnalysisSniff implements Sniff {
     $scopeInfo = $this->getOrCreateScopeInfo($currScope);
     if (!isset($scopeInfo->variables[$varName])) {
       $scopeInfo->variables[$varName] = new VariableInfo($varName);
-      if ($this->validUnusedVariableNames && in_array($varName, $this->validUnusedVariableNames)) {
+      $validUnusedVariableNames = (empty($this->validUnusedVariableNames))
+        ? []
+        : preg_split('/\s+/', trim($this->validUnusedVariableNames));
+      if (in_array($varName, $validUnusedVariableNames)) {
         $scopeInfo->variables[$varName]->ignoreUnused = true;
       }
     }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -47,6 +47,13 @@ class VariableAnalysisSniff implements Sniff {
    */
   public $validUnusedVariableNames = null;
 
+  /**
+   *  A PHP regexp string for variables that you want to ignore from unused
+   *  variable warnings. For example, to ignore the variables `$_junk` and
+   *  `$_unused`, this could be set to `'/^_/'`.
+   */
+  public $ignoreUnusedRegexp = null;
+
   public function register() {
     return [
       T_VARIABLE,
@@ -124,6 +131,9 @@ class VariableAnalysisSniff implements Sniff {
         ? []
         : preg_split('/\s+/', trim($this->validUnusedVariableNames));
       if (in_array($varName, $validUnusedVariableNames)) {
+        $scopeInfo->variables[$varName]->ignoreUnused = true;
+      }
+      if (isset($this->ignoreUnusedRegexp) && preg_match($this->ignoreUnusedRegexp, $varName) === 1) {
         $scopeInfo->variables[$varName]->ignoreUnused = true;
       }
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -448,6 +448,25 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
+  public function testAllowUnusedCaughtExceptionsIgnoresUnusedVariables() {
+    $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedCaughtExceptions',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      16,
+      27,
+      39,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
   public function testIgnoreUnusedRegexpIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -413,4 +413,17 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedErrors = [];
     $this->assertEquals($expectedErrors, $lines);
   }
+
+  public function testUnusedParams() {
+    $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      3,
+      14,
+      25,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -420,9 +420,9 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
-      3,
-      14,
-      25,
+      4,
+      16,
+      39,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -452,6 +452,22 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
+  public function testAllowUnusedFunctionParametersIgnoresUnusedVariables() {
+    $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedFunctionParameters',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      66,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
   public function testAllowUnusedCaughtExceptionsIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -425,6 +425,8 @@ class VariableAnalysisTest extends BaseTestCase {
       27,
       39,
       66,
+      72,
+      73,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -444,6 +446,8 @@ class VariableAnalysisTest extends BaseTestCase {
       16,
       39,
       66,
+      72,
+      73,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -463,6 +467,8 @@ class VariableAnalysisTest extends BaseTestCase {
       16,
       27,
       39,
+      72,
+      73,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -482,6 +488,7 @@ class VariableAnalysisTest extends BaseTestCase {
       16,
       27,
       39,
+      72,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -414,7 +414,22 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedErrors, $lines);
   }
 
-  public function testUnusedParams() {
+  public function testUnusedParamsAreReported() {
+    $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      16,
+      27,
+      39,
+      66,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testValidUnusedVariableNamesIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->ruleset->setSniffProperty(
@@ -427,6 +442,26 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       4,
       16,
+      39,
+      66,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testIgnoreUnusedRegexpIgnoresUnusedVariables() {
+    $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'ignoreUnusedRegexp',
+      '/^unused_/'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      16,
+      27,
       39,
     ];
     $this->assertEquals($expectedWarnings, $lines);

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -417,6 +417,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testUnusedParams() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUnusedVariableNames',
+      'ignored'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+function function_with_first_unused_param($unused, $param) {
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}
+
+function function_with_second_unused_param($param, $unused) {
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}
+
+function function_with_all_unused_params($unused, $unused_two) {
+    $param = 'hello';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}
+
+function function_with_no_unused_params($param, $param_two) {
+    echo $param;
+    echo $param_two;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
@@ -59,3 +59,11 @@ function function_with_no_unused_params($param, $param_two) {
     echo "xxx {$param} xxx";
     return $param;
 }
+
+function function_with_try_catch_and_unused_exception() {
+    try {
+        doAThing();
+    } catch (Exception $unused_param) {
+        echo "unused";
+    }
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
@@ -1,5 +1,6 @@
 <?php
 
+// The following line should report an unused variable
 function function_with_first_unused_param($unused, $param) {
     echo $param;
     echo "xxx $param xxx";
@@ -11,6 +12,7 @@ function function_with_first_unused_param($unused, $param) {
     return $param;
 }
 
+// The following line should report an unused variable
 function function_with_second_unused_param($param, $unused) {
     echo $param;
     echo "xxx $param xxx";
@@ -22,6 +24,18 @@ function function_with_second_unused_param($param, $unused) {
     return $param;
 }
 
+function function_with_second_unused_param_ignored($param, $ignored) {
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}
+
+// The following line should report an unused variable
 function function_with_all_unused_params($unused, $unused_two) {
     $param = 'hello';
     echo $param;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUnusedParamsFixture.php
@@ -67,3 +67,18 @@ function function_with_try_catch_and_unused_exception() {
         echo "unused";
     }
 }
+
+function function_with_multi_line_unused_params(
+    $unused,
+    $unused_two
+) {
+    $param = 'hello';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    $param = 'set the param';
+    echo $param;
+    echo "xxx $param xxx";
+    echo "xxx {$param} xxx";
+    return $param;
+}


### PR DESCRIPTION
There are already three options for ignoring unused variables. This PR adds documentation for those options and also adds a new option to allow ignoring variables by regular expression. This will bring the available options to the following:

- `allowUnusedFunctionParameters` (bool, default `false`): if set to true, function arguments will never be marked as unused.
- `allowUnusedCaughtExceptions` (bool, default `false`): if set to true, caught Exception variables will never be marked as unused.
- `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
- `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.

Fixes #21. 

To do
- [x] Add tests for allowed unused function arguments via `validUnusedVariableNames`
- [x] Convert `validUnusedVariableNames` to array late
- [x] Add `ignoreUnusedRegexp` option to allow unused arguments regexp
- [x] Add tests for multi-line function arguments
- [x] Add documentation for `allowUnusedFunctionParameters`, `validUnusedVariableNames`, `allowUnusedCaughtExceptions` and `ignoreUnusedRegexp`
