### PR TITLE
Tests: sort line numbers

### DIFF
--- a/VariableAnalysis/Tests/BaseTestCase.php
+++ b/VariableAnalysis/Tests/BaseTestCase.php
@@ -19,7 +19,9 @@ class BaseTestCase extends TestCase {
   }
 
   public function getLineNumbersFromMessages(array $messages): array {
-    return array_keys($messages);
+    $lines = array_keys($messages);
+    sort($lines);
+    return $lines;
   }
 
   public function getWarningLineNumbersFromFile(LocalFile $phpcsFile): array {

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -73,8 +73,8 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
-      7,
       4,
+      7,
       22,
     ];
     $this->assertEquals($expectedWarnings, $lines);
@@ -214,8 +214,8 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
-      20,
       8,
+      20,
       32,
       33,
       34,
@@ -363,13 +363,13 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
+      2,
       7,
       10,
-      2,
-      23,
-      26,
       14,
       19,
+      23,
+      26,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }


### PR DESCRIPTION
Errors and warnings (messages) are not always added in line-number order since they can be added by different sniffs or different parts of a sniff in whatever order the sniff chooses. That's fine, but our tests aren't particularly concerned with the order of the messages, just if they exist on the correct lines.

This change sorts all the line numbers being reported for tests so that we can assume they are always in increasing integer order.