### PR TITLE
Remove null coalesce

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -79,7 +79,7 @@ class VariableAnalysisSniff implements Sniff {
         $passByRefFunctions[$function] = explode(',', $args);
       }
     }
-    return $passByRefFunctions[$functionName] ?? null;
+    return isset($passByRefFunctions[$functionName]) ? $passByRefFunctions[$functionName] : null;
   }
 
   /**


### PR DESCRIPTION
The current min version for this standard is PHP 5.4 which does not have it.