### PR TITLE
Add composer autoload configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
     "config": {
         "sort-order": true
     },
+    "autoload": {
+        "psr-4": {
+            "VariableAnalysis\\": "VariableAnalysis/"
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {


### PR DESCRIPTION
Without this, there is no generic way how to reference to sniffs here. This also means it can't be used with EasyCodingStandard