### PR TITLE
Include `parent` keyword as static reference

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -364,6 +364,7 @@ class VariableAnalysisSniff implements Sniff {
     $staticReferences = [
       T_STRING,
       T_SELF,
+      T_PARENT,
       T_STATIC,
     ];
     if (! in_array($tokens[$classNamePtr]['code'], $staticReferences, true)) {

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -63,3 +63,10 @@ class ClassWithLateStaticBinding {
         static::some_method(static::CONSTANT, $param);
     }
 }
+
+class ChildClassWithMembers extends ClassWithMembers {
+    function method_with_parent_reference() {
+        echo self::$static_member_var;
+        echo parent::$no_such_static_member_var;
+    }
+}


### PR DESCRIPTION
Fixes #43