### PR TITLE
Remove typehints to support PHP 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/php:7.1.19-fpm-node-browsers
+      - image: circleci/php:7.0-apache-stretch-node-browsers
     steps:
       - checkout
       - run: composer install

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -5,7 +5,7 @@ namespace VariableAnalysis\Lib;
 use PHP_CodeSniffer\Files\File;
 
 class Helpers {
-  public static function findContainingOpeningBracket(File $phpcsFile, int $stackPtr) {
+  public static function findContainingOpeningBracket(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     if (isset($tokens[$stackPtr]['nested_parenthesis'])) {
       $openPtrs = array_keys($tokens[$stackPtr]['nested_parenthesis']);
@@ -14,7 +14,7 @@ class Helpers {
     return false;
   }
 
-  public static function findParenthesisOwner(File $phpcsFile, int $stackPtr) {
+  public static function findParenthesisOwner(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     return $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
   }
@@ -40,7 +40,7 @@ class Helpers {
     return false;
   }
 
-  public static function findPreviousFunctionPtr(File $phpcsFile, int $openPtr) {
+  public static function findPreviousFunctionPtr(File $phpcsFile, $openPtr) {
     // Function names are T_STRING, and return-by-reference is T_BITWISE_AND,
     // so we look backwards from the opening bracket for the first thing that
     // isn't a function name, reference sigil or whitespace and check if it's a
@@ -49,7 +49,7 @@ class Helpers {
     return $phpcsFile->findPrevious($functionPtrTypes, $openPtr - 1, null, true, null, true);
   }
 
-  public static function findFunctionCall(File $phpcsFile, int $stackPtr) {
+  public static function findFunctionCall(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
@@ -103,7 +103,7 @@ class Helpers {
     return $argPtrs;
   }
 
-  public static function findWhereAssignExecuted(File $phpcsFile, int $stackPtr) {
+  public static function findWhereAssignExecuted(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     //  Write should be recorded at the next statement to ensure we treat the
@@ -132,7 +132,7 @@ class Helpers {
     return $assignEndTokens[0];
   }
 
-  public static function isNextThingAnAssign(File $phpcsFile, int $stackPtr) {
+  public static function isNextThingAnAssign(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     // Is the next non-whitespace an assignment?
@@ -149,7 +149,7 @@ class Helpers {
     return preg_replace('/[{}$]/', '', $varName);
   }
 
-  public static function findFunctionPrototype(File $phpcsFile, int $stackPtr) {
+  public static function findFunctionPrototype(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];
 
@@ -164,7 +164,7 @@ class Helpers {
     return false;
   }
 
-  public static function findVariableScope(File $phpcsFile, int $stackPtr) {
+  public static function findVariableScope(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -64,7 +64,7 @@ class VariableAnalysisSniff implements Sniff {
     ];
   }
 
-  private function getPassByReferenceFunction(string $functionName) {
+  private function getPassByReferenceFunction($functionName) {
     $passByRefFunctions = Constants::getPassByReferenceFunctions();
     //  Magic to modfy $passByRefFunctions with any site-specific settings.
     if (!empty($this->sitePassByRefFunctions)) {

--- a/VariableAnalysis/Tests/BaseTestCase.php
+++ b/VariableAnalysis/Tests/BaseTestCase.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
 
 class BaseTestCase extends TestCase {
-  public function prepareLocalFileForSniffs($sniffFiles, string $fixtureFile): LocalFile {
+  public function prepareLocalFileForSniffs($sniffFiles, $fixtureFile): LocalFile {
     $config = new Config();
     $ruleset = new Ruleset($config);
     if (! is_array($sniffFiles)) {
@@ -39,7 +39,7 @@ class BaseTestCase extends TestCase {
     return [__DIR__ . '/../../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php'];
   }
 
-  public function getFixture(string $fixtureFilename): string {
+  public function getFixture($fixtureFilename) {
     return __DIR__ . '/CodeAnalysis/fixtures/' . $fixtureFilename;
   }
 }

--- a/VariableAnalysis/Tests/BaseTestCase.php
+++ b/VariableAnalysis/Tests/BaseTestCase.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
 
 class BaseTestCase extends TestCase {
-  public function prepareLocalFileForSniffs($sniffFiles, $fixtureFile): LocalFile {
+  public function prepareLocalFileForSniffs($sniffFiles, $fixtureFile) {
     $config = new Config();
     $ruleset = new Ruleset($config);
     if (! is_array($sniffFiles)) {
@@ -21,21 +21,21 @@ class BaseTestCase extends TestCase {
     return new LocalFile($fixtureFile, $ruleset, $config);
   }
 
-  public function getLineNumbersFromMessages(array $messages): array {
+  public function getLineNumbersFromMessages(array $messages) {
     $lines = array_keys($messages);
     sort($lines);
     return $lines;
   }
 
-  public function getWarningLineNumbersFromFile(LocalFile $phpcsFile): array {
+  public function getWarningLineNumbersFromFile(LocalFile $phpcsFile) {
     return $this->getLineNumbersFromMessages($phpcsFile->getWarnings());
   }
 
-  public function getErrorLineNumbersFromFile(LocalFile $phpcsFile): array {
+  public function getErrorLineNumbersFromFile(LocalFile $phpcsFile) {
     return $this->getLineNumbersFromMessages($phpcsFile->getErrors());
   }
 
-  public function getSniffFiles(): array {
+  public function getSniffFiles() {
     return [__DIR__ . '/../../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php'];
   }
 


### PR DESCRIPTION
I didn't realize that the typehints I was using in this sniff were not a feature added until PHP 7. Since this sniff supports PHP 5.4, I had to remove them.

Fixes #46