### PR TITLE
Support shorthand list assignment

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -5,6 +5,25 @@ namespace VariableAnalysis\Lib;
 use PHP_CodeSniffer\Files\File;
 
 class Helpers {
+  public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
+    $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
+    return $phpcsFile->findPrevious(T_OPEN_SHORT_ARRAY, $stackPtr - 1, $previousStatementPtr);
+  }
+
+  public static function findContainingClosingSquareBracket(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
+    $endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1);
+    if (! $endOfStatementPtr) {
+      return false;
+    }
+    return $phpcsFile->findNext(T_CLOSE_SHORT_ARRAY, $stackPtr + 1, $endOfStatementPtr);
+  }
+
+  public static function getPreviousStatementPtr(File $phpcsFile, $stackPtr) {
+    return $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1) ?: 1;
+  }
+
   public static function findContainingOpeningBracket(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     if (isset($tokens[$stackPtr]['nested_parenthesis'])) {

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -541,4 +541,16 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testAllowDestructuringAssignment() {
+    $fixtureFile = $this->getFixture('DestructuringFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      12,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/DestructuringFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/DestructuringFixture.php
@@ -1,0 +1,16 @@
+<?php
+function function_with_destructuring_assignment() {
+    [$a, $b] = [1, 2];
+    [$c, $d] = [3, 4]; // unused
+    echo $a;
+    echo $b;
+    echo $c;
+}
+
+function function_with_destructuring_assignment_using_list() {
+    list( $a, $b ) = [1, 2];
+    list( $c, $d ) = [3, 4]; // unused
+    echo $a;
+    echo $b;
+    echo $c;
+}


### PR DESCRIPTION
This adds support for shorthand list assignment, also known as shorthand array destructuring assignment.

That is, this will now count as assignment of both `$a` and `$b`.

```php
[$a, $b] = [1, 2];
```

Fixes #48