### PR TITLE
Correctly mark pass-by-reference variables in use() constructs

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -274,6 +274,14 @@ class VariableAnalysisSniff implements Sniff {
         // TODO: typeHints in use?
         $this->markVariableDeclaration($varName, 'bound', null, $stackPtr, $functionPtr);
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
+
+        // Are we pass-by-reference?
+        $referencePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true, null, true);
+        if (($referencePtr !== false) && ($tokens[$referencePtr]['code'] === T_BITWISE_AND)) {
+          $varInfo = $this->getOrCreateVariableInfo($varName, $functionPtr);
+          $varInfo->passByReference = true;
+        }
+
         return true;
       }
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -37,6 +37,15 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
+  public function testFunctionWithUseReferenceWarnings() {
+    $fixtureFile = $this->getFixture('FunctionWithUseReferenceFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedErrors = [];
+    $this->assertEquals($expectedErrors, $lines);
+  }
+
   public function testFunctionWithDefaultParamErrors() {
     $fixtureFile = $this->getFixture('FunctionWithDefaultParamFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUseReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUseReferenceFixture.php
@@ -1,0 +1,7 @@
+<?php
+
+$ref = 0;
+
+$function_with_use_reference = function () use (&$ref) {
+    $ref = 1;
+};


### PR DESCRIPTION
Pass-by-reference variables are currently correctly [marked as such](https://github.com/sirbrillig/phpcs-variable-analysis/blob/d7652aff800e43cc54ccdcc0d4e2956a10ba7a07/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php#L251-L255) in function parameters, but not in anonymous functions' `use` constructs.

This PR marks according pass-by-reference variables correctly and thus fixes #51.