### PR TITLE
Option for undefined vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The available options are as follows:
 - `allowUnusedCaughtExceptions` (bool, default `false`): if set to true, caught Exception variables will never be marked as unused.
 - `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
 - `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.
+- `validUndefinedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from undefined variable warnings. For example, to ignore the variables `$post` and `$undefined`, this could be set to `'post undefined'`.
 
 To set these these options, you must use XML in your ruleset. For details, see the [phpcs customizable sniff properties page](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties). Here is an example that ignores all variables that start with an underscore:
 

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -17,6 +17,7 @@ class VariableInfo {
   public $firstInitialized;
   public $firstRead;
   public $ignoreUnused = false;
+  public $ignoreUndefined = false;
 
   public static $scopeTypeDescriptions = array(
     'local'  => 'variable',

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -84,7 +84,10 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       4,
       7,
-      22,
+      8,
+      23,
+      28,
+      29
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -355,8 +358,12 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       10,
       11,
-      20,
-      21,
+      12,
+      13,
+      22,
+      23,
+      24,
+      25
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -550,6 +557,45 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       4,
       12,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testValidUndefinedVariableNamesIgnoresVarsInGlobalScope() {
+    $fixtureFile = $this->getFixture('FunctionWithGlobalVarFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUndefinedVariableNames',
+      'ice_cream'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      7,
+      23,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testValidUndefinedVariableNamesIgnoresUndefinedProperties() {
+    $fixtureFile = $this->getFixture('ClassReferenceFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUndefinedVariableNames',
+      'ignored_property'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      10,
+      11,
+      22,
+      23,
+      24,
+      25
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassReferenceFixture.php
@@ -9,6 +9,8 @@ class ClassWithSymbolicRefProperty {
             $this -> $property = 'some value';
             $this->$undefined_property = 'some value';
             $this -> $undefined_property = 'some value';
+            $this->$ignored_property = 'some value';
+            $this -> $ignored_property = 'some value';
         }
     }
 
@@ -19,6 +21,8 @@ class ClassWithSymbolicRefProperty {
             $this -> $method();
             $this->$undefined_method();
             $this -> $undefined_method();
+            $this->$ignored_method();
+            $this -> $ignored_method();
         }
     }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithGlobalVarFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithGlobalVarFixture.php
@@ -5,6 +5,7 @@ function function_with_global_var() {
 
     echo $var;
     echo $var3;
+    echo $ice_cream;
     return $var2;
 }
 
@@ -20,4 +21,11 @@ function function_with_superglobals() {
     echo print_r($_ENV, true);
     echo "{$GLOBALS['whatever']}";
     echo "{$GLOBALS['whatever']} $var";
+}
+
+// Variables within the global scope
+$cherry = 'topping';
+$sunday = $ice_cream . 'and a ' . $cherry;
+if ( $ice_cream ) {
+    echo 'Two scoops please!';
 }


### PR DESCRIPTION
I made an issue an issue about this #55 before realizing it wasn't an option, so I thought I'd implement it and submit the feature request.

This feature should be used with caution, but for certain settings, notably the WordPress $post global variable, it is nice to avoid the repetition of writing `global $post` on all WordPress theme included files in the loop. This helps reduce noise when reviewing WordPress themes, while not having to disable variable analysis completely.

I also added some tests for this in the global space.