### PR TITLE
Add allowUnusedParametersBeforeUsed option

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -3,6 +3,7 @@
 namespace VariableAnalysis\Lib;
 
 use PHP_CodeSniffer\Files\File;
+use VariableAnalysis\Lib\VariableInfo;
 
 class Helpers {
   public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -87,7 +87,6 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
 
     // Slight hack: also allow this to find args for array constructor.
-    // TODO: probably should refactor into three functions: arg-finding and bracket-finding
     if (($tokens[$stackPtr]['code'] !== T_STRING) && ($tokens[$stackPtr]['code'] !== T_ARRAY)) {
       // Assume $stackPtr is something within the brackets, find our function call
       $stackPtr = Helpers::findFunctionCall($phpcsFile, $stackPtr);

--- a/VariableAnalysis/Lib/ScopeInfo.php
+++ b/VariableAnalysis/Lib/ScopeInfo.php
@@ -13,6 +13,5 @@ class ScopeInfo {
 
   public function __construct($currScope) {
     $this->owner = $currScope;
-    // TODO: extract opener/closer
   }
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -65,7 +65,7 @@ class VariableAnalysisSniff implements Sniff {
    * Allows unused arguments in a function definition if they are
    * followed by an argument which is used.
    */
-  public $ignoreUnusedArgsBeforeUsed = false;
+  public $allowUnusedParametersBeforeUsed = false;
 
   public function register() {
     return [
@@ -954,7 +954,7 @@ class VariableAnalysisSniff implements Sniff {
     if ($this->allowUnusedFunctionParameters && $varInfo->scopeType === 'param') {
       return;
     }
-    if ($this->ignoreUnusedArgsBeforeUsed && $varInfo->scopeType === 'param' && $this->areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
+    if ($this->allowUnusedParametersBeforeUsed && $varInfo->scopeType === 'param' && $this->areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
       return;
     }
     if ($varInfo->passByReference && isset($varInfo->firstInitialized)) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -59,7 +59,7 @@ class VariableAnalysisSniff implements Sniff {
    *  ignore from undefined variable warnings. For example, to ignore the variables
    *  `$post` and `$undefined`, this could be set to `'post undefined'`.
    */
-  public $validUdefinedVariableNames = null;
+  public $validUndefinedVariableNames = null;
 
   /**
    * Allows unused arguments in a function definition if they are

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -246,7 +246,6 @@ class VariableAnalysisSniff implements Sniff {
       return false;
     }
     if (isset($varInfo->firstDeclared) && $varInfo->firstDeclared <= $stackPtr) {
-      // TODO: do we want to check scopeType here?
       return false;
     }
     if (isset($varInfo->firstInitialized) && $varInfo->firstInitialized <= $stackPtr) {
@@ -284,7 +283,6 @@ class VariableAnalysisSniff implements Sniff {
     if (($functionPtr !== false)
       && (($tokens[$functionPtr]['code'] === T_FUNCTION)
       || ($tokens[$functionPtr]['code'] === T_CLOSURE))) {
-      // TODO: typeHint
       $this->markVariableDeclaration($varName, 'param', null, $stackPtr, $functionPtr);
       // Are we pass-by-reference?
       $referencePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true, null, true);
@@ -310,7 +308,6 @@ class VariableAnalysisSniff implements Sniff {
       // $functionPtr is at the use, we need the function keyword for start of scope.
       $functionPtr = $phpcsFile->findPrevious(T_CLOSURE, $functionPtr - 1, $currScope + 1, false, null, true);
       if ($functionPtr !== false) {
-        // TODO: typeHints in use?
         $this->markVariableDeclaration($varName, 'bound', null, $stackPtr, $functionPtr);
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
 
@@ -340,7 +337,6 @@ class VariableAnalysisSniff implements Sniff {
     $catchPtr = $phpcsFile->findPrevious(T_WHITESPACE, $openPtr - 1, null, true, null, true);
     if (($catchPtr !== false) && ($tokens[$catchPtr]['code'] === T_CATCH)) {
       // Scope of the exception var is actually the function, not just the catch block.
-      // TODO: typeHint
       $this->markVariableDeclaration($varName, 'local', null, $stackPtr, $currScope, true);
       $this->markVariableAssignment($varName, $stackPtr, $currScope);
       if ($this->allowUnusedCaughtExceptions) {
@@ -428,7 +424,6 @@ class VariableAnalysisSniff implements Sniff {
 
   protected function checkForStaticOutsideClass(File $phpcsFile, $stackPtr, $varName, $currScope) {
     // Are we refering to self:: outside a class?
-    // TODO: not sure this is our business or should be some other sniff.
 
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -615,7 +615,7 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-      'ignoreUnusedArgsBeforeUsed',
+      'allowUnusedParametersBeforeUsed',
       'true'
     );
     $phpcsFile->process();

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -599,4 +599,32 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testUnusedArgumentsBeforeUsedArgumentsAreFound() {
+    $fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      5,
+      8,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testUnusedArgumentsBeforeUsedArgumentsAreIgnoredIfSet() {
+    $fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'ignoreUnusedArgsBeforeUsed',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      8,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -1,9 +1,7 @@
 <?php
 namespace VariableAnalysis\Tests;
 
-use PHP_CodeSniffer\Files\LocalFile;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Config;
+use VariableAnalysis\Tests\BaseTestCase;
 
 class VariableAnalysisTest extends BaseTestCase {
   public function testFunctionWithoutParamsErrors() {

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedAfterUsedFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedAfterUsedFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+add_action( 'delete_post_meta', 'check_thumbnail_updated_post_meta', -1000, 3 );
+function check_thumbnail_updated_post_meta(
+    $meta_id,
+    $post_id,
+    $meta_key,
+    $foobar
+) {
+    echo $post_id;
+    echo $meta_key;
+}

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "phpunit/phpunit": "^6.5",
+        "sirbrillig/phpcs-import-detection": "^1.1",
         "squizlabs/php_codesniffer": "^3.1",
         "limedeck/phpunit-detailed-printer": "^3.1"
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,4 +29,5 @@
     </rule>
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>
+    <rule ref="ImportDetection" />
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />
         <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+        <exclude name="Generic.Files.LineLength.TooLong" />
     </rule>
     <arg name="tab-width" value="2"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent">


### PR DESCRIPTION
This adds a new option, `allowUnusedParametersBeforeUsed`, which will allow unused function arguments if they come before a used argument.

Fixes #57 