### PR TITLE
Make allowUnusedParametersBeforeUsed default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The available options are as follows:
 
 - `allowUnusedFunctionParameters` (bool, default `false`): if set to true, function arguments will never be marked as unused.
 - `allowUnusedCaughtExceptions` (bool, default `false`): if set to true, caught Exception variables will never be marked as unused.
-- `allowUnusedParametersBeforeUsed` (bool, default `false`): if set to true, unused function arguments will be ignored if they are followed by used function arguments.
+- `allowUnusedParametersBeforeUsed` (bool, default `true`): if set to true, unused function arguments will be ignored if they are followed by used function arguments.
 - `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
 - `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.
 - `validUndefinedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from undefined variable warnings. For example, to ignore the variables `$post` and `$undefined`, this could be set to `'post undefined'`.

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -65,7 +65,7 @@ class VariableAnalysisSniff implements Sniff {
    * Allows unused arguments in a function definition if they are
    * followed by an argument which is used.
    */
-  public $allowUnusedParametersBeforeUsed = false;
+  public $allowUnusedParametersBeforeUsed = true;
 
   public function register() {
     return [

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -192,6 +192,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testFunctionWithClosureErrors() {
     $fixtureFile = $this->getFixture('FunctionWithClosureFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
     $expectedErrors = [
@@ -203,6 +208,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testFunctionWithClosureWarnings() {
     $fixtureFile = $this->getFixture('FunctionWithClosureFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
@@ -439,6 +449,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testVariableFunctionCallsCountAsUsage() {
     $fixtureFile = $this->getFixture('FunctionWithVariableCallFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [18];

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -47,6 +47,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testFunctionWithDefaultParamErrors() {
     $fixtureFile = $this->getFixture('FunctionWithDefaultParamFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
     $expectedErrors = [];
@@ -56,6 +61,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testFunctionWithDefaultParamWarnings() {
     $fixtureFile = $this->getFixture('FunctionWithDefaultParamFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
@@ -369,6 +379,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testCompactErrors() {
     $fixtureFile = $this->getFixture('CompactFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
     $expectedErrors = [];
@@ -378,6 +393,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testCompactWarnings() {
     $fixtureFile = $this->getFixture('CompactFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
@@ -455,6 +475,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testUnusedParamsAreReported() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
@@ -472,6 +497,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testValidUnusedVariableNamesIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
       'validUnusedVariableNames',
@@ -495,6 +525,11 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
       'allowUnusedFunctionParameters',
       'true'
     );
@@ -509,6 +544,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testAllowUnusedCaughtExceptionsIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
       'allowUnusedCaughtExceptions',
@@ -530,6 +570,11 @@ class VariableAnalysisTest extends BaseTestCase {
   public function testIgnoreUnusedRegexpIgnoresUnusedVariables() {
     $fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
       'ignoreUnusedRegexp',
@@ -598,9 +643,14 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
-  public function testUnusedArgumentsBeforeUsedArgumentsAreFound() {
+  public function testUnusedArgumentsBeforeUsedArgumentsAreFoundIfFalse() {
     $fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'false'
+    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
@@ -610,14 +660,9 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
-  public function testUnusedArgumentsBeforeUsedArgumentsAreIgnoredIfSet() {
+  public function testUnusedArgumentsBeforeUsedArgumentsAreIgnoredByDefault() {
     $fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
-    $phpcsFile->ruleset->setSniffProperty(
-      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-      'allowUnusedParametersBeforeUsed',
-      'true'
-    );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -671,6 +671,8 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       5,
       8,
+      16,
+      19,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -682,6 +684,7 @@ class VariableAnalysisTest extends BaseTestCase {
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
       8,
+      19,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedAfterUsedFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedAfterUsedFixture.php
@@ -10,3 +10,16 @@ function check_thumbnail_updated_post_meta(
     echo $post_id;
     echo $meta_key;
 }
+
+function inner_function() {
+    $foo = function(
+        $meta_id,
+        $post_id,
+        $meta_key,
+        $foobar
+    ) {
+        echo $post_id;
+        echo $meta_key;
+    }
+    $foo();
+}


### PR DESCRIPTION
#58 added a new option `allowUnusedParametersBeforeUsed`, which, if set, ignores unused function arguments if they come before used function arguments. Since it's probably rare that those warnings would be needed, this PR changes that option to default to `true`.