### PR TITLE
Ignore numeric variables

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -608,6 +608,10 @@ class VariableAnalysisSniff implements Sniff {
     return true;
   }
 
+  protected function checkForNumericVariable($varName) {
+    return is_numeric(substr($varName, 0, 1));
+  }
+
   protected function checkForForeachLoopVar(File $phpcsFile, $stackPtr, $varName, $currScope) {
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];
@@ -827,6 +831,11 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
 
+    // Are we a numeric variable used for constructs like preg_replace?
+    if ($this->checkForNumericVariable($varName)) {
+      return;
+    }
+
     // OK, we don't appear to be a write to the var, assume we're a read.
     $this->markVariableReadAndWarnIfUndefined($phpcsFile, $varName, $stackPtr, $currScope);
   }
@@ -855,9 +864,16 @@ class VariableAnalysisSniff implements Sniff {
       if ($this->checkForThisWithinClass($phpcsFile, $stackPtr, $varName, $currScope)) {
         continue;
       }
+
       if ($this->checkForSuperGlobal($phpcsFile, $stackPtr, $varName, $currScope)) {
         continue;
       }
+
+      // Are we a numeric variable used for constructs like preg_replace?
+      if ($this->checkForNumericVariable($varName)) {
+        continue;
+      }
+
       $this->markVariableReadAndWarnIfUndefined($phpcsFile, $varName, $stackPtr, $currScope);
     }
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -688,4 +688,16 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testPregReplaceIgnoresNumericVariables() {
+    $fixtureFile = $this->getFixture('PregReplaceFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      15,
+      20,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/PregReplaceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/PregReplaceFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+function doPregReplaceWithIgnoredVariable($subject) {
+    $selector = 'good morning';
+    return preg_replace('/(hello \w+)/', "$selector$1", $subject, 1);
+}
+
+function doPregReplaceWithZeroIgnoredVariable($subject) {
+    $selector = 'good morning';
+    return preg_replace('/(hello \w+)/', "$selector$0", $subject, 1);
+}
+
+function doPregReplaceWithNonIgnoredVariable($subject) {
+    $selector = 'good morning';
+    return preg_replace('/(hello \w+)/', "$selector$bad", $subject, 1);
+}
+
+function doPregReplaceWithNonIgnoredAndIgnoredVariable($subject) {
+    $selector = 'good morning';
+    return preg_replace('/(hello \w+)/', "$selector$1$bad", $subject, 1);
+}


### PR DESCRIPTION
Variable names which start with a number are illegal in PHP, but the pattern of a `$` followed by a number inside a string is used by some constructs such as `preg_replace()`. This change simply does not process symbols that look like variables if the variable name starts with a number.

Fixes #60 