### PR TITLE
Handle variable class static refs

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -409,6 +409,7 @@ class VariableAnalysisSniff implements Sniff {
       T_SELF,
       T_PARENT,
       T_STATIC,
+      T_VARIABLE,
     ];
     if (! in_array($tokens[$classNamePtr]['code'], $staticReferences, true)) {
       return false;

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -161,7 +161,7 @@ class VariableAnalysisTest extends BaseTestCase {
       13,
       18,
       19,
-      62,
+      64,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -57,10 +57,14 @@ class ClassWithMembers {
 }
 
 class ClassWithLateStaticBinding {
+    public static $static_member_var;
+
     static function method_with_late_static_binding($param) {
         static::some_method($param);
-        static::some_method($var);
+        static::some_method($var); // should report a warning
         static::some_method(static::CONSTANT, $param);
+        $called_class = get_called_class();
+        echo $called_class::$static_member_var;
     }
 }
 

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithVariableCallFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithVariableCallFixture.php
@@ -41,4 +41,14 @@ class MyClass {
     public function funcUsingPropertyReferenceWithStatic($meta) {
         return static::$$meta;
     }
+
+    public function funcUsingPropertyReferenceWithVariableClass($meta) {
+        $called_class = get_called_class();
+        return $called_class::$$meta;
+    }
+
+    public function funcUsingNamedPropertyReferenceWithVariableClass() {
+        $called_class = get_called_class();
+        return $called_class::$staticProperty;
+    }
 }


### PR DESCRIPTION
When I was checking for all the different ways to reference static properties and functions, somehow I missed the formation `$variable::$property` (a static property on a dynamic class reference). This corrects that failure.

Fixes #62 