### PR TITLE
Add ignore unused foreach option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 phpunit.xml
 .phpcs.xml
 phpcs.xml
+tags

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The available options are as follows:
 - `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
 - `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.
 - `validUndefinedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from undefined variable warnings. For example, to ignore the variables `$post` and `$undefined`, this could be set to `'post undefined'`.
+- `ignoreUnusedForeachVariables` (bool, default `false`): if set to true, unused keys or values created by the `as` statement in a `foreach` loop will never be marked as unused.
 
 To set these these options, you must use XML in your ruleset. For details, see the [phpcs customizable sniff properties page](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties). Here is an example that ignores all variables that start with an underscore:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The available options are as follows:
 - `validUnusedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$junk` and `$unused`, this could be set to `'junk unused'`.
 - `ignoreUnusedRegexp` (string, default `null`): a PHP regexp string (note that this requires explicit delimiters) for variables that you want to ignore from unused variable warnings. For example, to ignore the variables `$_junk` and `$_unused`, this could be set to `'/^_/'`.
 - `validUndefinedVariableNames` (string, default `null`): a space-separated list of names of placeholder variables that you want to ignore from undefined variable warnings. For example, to ignore the variables `$post` and `$undefined`, this could be set to `'post undefined'`.
-- `ignoreUnusedForeachVariables` (bool, default `false`): if set to true, unused keys or values created by the `as` statement in a `foreach` loop will never be marked as unused.
+- `allowUnusedForeachVariables` (bool, default `false`): if set to true, unused keys or values created by the `as` statement in a `foreach` loop will never be marked as unused.
 
 To set these these options, you must use XML in your ruleset. For details, see the [phpcs customizable sniff properties page](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties). Here is an example that ignores all variables that start with an underscore:
 

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -18,6 +18,7 @@ class VariableInfo {
   public $firstRead;
   public $ignoreUnused = false;
   public $ignoreUndefined = false;
+  public $isForeachLoopVar = false;
 
   public static $scopeTypeDescriptions = array(
     'local'  => 'variable',

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -71,7 +71,7 @@ class VariableAnalysisSniff implements Sniff {
    * If set to true, unused keys or values created by the `as` statement
    * in a `foreach` loop will never be marked as unused.
    */
-  public $ignoreUnusedForeachVariables = false;
+  public $allowUnusedForeachVariables = false;
 
   public function register() {
     return [
@@ -982,7 +982,7 @@ class VariableAnalysisSniff implements Sniff {
     if ($this->allowUnusedParametersBeforeUsed && $varInfo->scopeType === 'param' && $this->areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
       return;
     }
-    if ($this->ignoreUnusedForeachVariables && $varInfo->isForeachLoopVar) {
+    if ($this->allowUnusedForeachVariables && $varInfo->isForeachLoopVar) {
       return;
     }
     if ($varInfo->passByReference && isset($varInfo->firstInitialized)) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -67,6 +67,12 @@ class VariableAnalysisSniff implements Sniff {
    */
   public $allowUnusedParametersBeforeUsed = true;
 
+  /**
+   * If set to true, unused keys or values created by the `as` statement
+   * in a `foreach` loop will never be marked as unused.
+   */
+  public $ignoreUnusedForeachVariables = false;
+
   public function register() {
     return [
       T_VARIABLE,

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -650,8 +650,10 @@ class VariableAnalysisSniff implements Sniff {
     if ($phpcsFile->findPrevious(T_AS, $stackPtr - 1, $openParenPtr) === false) {
       return false;
     }
-
     $this->markVariableAssignment($varName, $stackPtr, $currScope);
+    $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
+    $varInfo->isForeachLoopVar = true;
+
     return true;
   }
 
@@ -978,6 +980,9 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
     if ($this->allowUnusedParametersBeforeUsed && $varInfo->scopeType === 'param' && $this->areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
+      return;
+    }
+    if ($this->ignoreUnusedForeachVariables && $varInfo->isForeachLoopVar) {
       return;
     }
     if ($varInfo->passByReference && isset($varInfo->firstInitialized)) {

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -713,8 +713,14 @@ class VariableAnalysisTest extends BaseTestCase {
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
       5,
-      12,
-      19,
+      7,
+      8,
+      14,
+      16,
+      17,
+      23,
+      25,
+      26,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -729,7 +735,14 @@ class VariableAnalysisTest extends BaseTestCase {
     );
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
-    $expectedWarnings = [];
+    $expectedWarnings = [
+      7,
+      8,
+      16,
+      17,
+      25,
+      26,
+    ];
     $this->assertEquals($expectedWarnings, $lines);
   }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -721,6 +721,9 @@ class VariableAnalysisTest extends BaseTestCase {
       23,
       25,
       26,
+      32,
+      33,
+      34,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -742,6 +745,8 @@ class VariableAnalysisTest extends BaseTestCase {
       17,
       25,
       26,
+      33,
+      34,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -706,7 +706,7 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-      'ignoreUnusedForeachVariables',
+      'allowUnusedForeachVariables',
       'false'
     );
     $phpcsFile->process();
@@ -730,7 +730,7 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->ruleset->setSniffProperty(
       'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-      'ignoreUnusedForeachVariables',
+      'allowUnusedForeachVariables',
       'true'
     );
     $phpcsFile->process();

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -700,4 +700,36 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testUnusedForeachVariablesAreNotIgnoredByDefault() {
+    $fixtureFile = $this->getFixture('UnusedForeachFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'ignoreUnusedForeachVariables',
+      'false'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      5,
+      12,
+      19,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testUnusedForeachVariablesAreIgnoredIfSet() {
+    $fixtureFile = $this->getFixture('UnusedForeachFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'ignoreUnusedForeachVariables',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+function loopWithUnusedKey() {
+    $array = [];
+    foreach ( $array as $key => $value ) {
+        echo $value;
+    }
+}
+
+function loopWithUnusedValue() {
+    $array = [];
+    foreach ( $array as $key => $value ) {
+        echo $key;
+    }
+}
+
+function loopWithUnusedKeyAndValue() {
+    $array = [];
+    foreach ( $array as $key => $value ) {
+        echo 'hello';
+    }
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
@@ -26,3 +26,11 @@ function loopWithUnusedKeyAndValue() {
         echo $undefined; // should always be marked as undefined
     }
 }
+
+function loopWithUnusedValueOnly() {
+    $array = [];
+    foreach ( $array as $value ) { // maybe marked as unused
+        $unused = 'foobar'; // should always be marked as unused
+        echo $undefined; // should always be marked as undefined
+    }
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedForeachFixture.php
@@ -2,21 +2,27 @@
 
 function loopWithUnusedKey() {
     $array = [];
-    foreach ( $array as $key => $value ) {
+    foreach ( $array as $key => $value ) { // maybe marked as unused
         echo $value;
+        $unused = 'foobar'; // should always be marked as unused
+        echo $undefined; // should always be marked as undefined
     }
 }
 
 function loopWithUnusedValue() {
     $array = [];
-    foreach ( $array as $key => $value ) {
+    foreach ( $array as $key => $value ) { // maybe marked as unused
         echo $key;
+        $unused = 'foobar'; // should always be marked as unused
+        echo $undefined; // should always be marked as undefined
     }
 }
 
 function loopWithUnusedKeyAndValue() {
     $array = [];
-    foreach ( $array as $key => $value ) {
+    foreach ( $array as $key => $value ) { // maybe marked as unused
         echo 'hello';
+        $unused = 'foobar'; // should always be marked as unused
+        echo $undefined; // should always be marked as undefined
     }
 }


### PR DESCRIPTION
This adds a new option, `allowUnusedForeachVariables`. If the option is set to true, it will cause unused keys or values created by the `as` statement in a `foreach` loop to never be marked as unused.

With this option unset, the following block would produce two warnings. Neither `$key` nor `$value` are used. With the option set, neither of these warnings will be recorded.

```php
foreach ($array as $key => $value) {
  echo 'hello';
}
```

Fixes #65 