### PR TITLE
Allow self within class method closures

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -450,14 +450,8 @@ class VariableAnalysisSniff implements Sniff {
     }
     $errorClass = $code === T_SELF ? 'SelfOutsideClass' : 'StaticOutsideClass';
     $staticRefType = $code === T_SELF ? 'self::' : 'static::';
-    if (!empty($token['conditions'])) {
-      if (Helpers::areAnyConditionsAClosure($phpcsFile, $token['conditions'])) {
-        $phpcsFile->addError("Use of {$staticRefType}%s inside closure.", $stackPtr, $errorClass, ["\${$varName}"]);
-        return true;
-      }
-      if (Helpers::areAnyConditionsAClass($token['conditions'])) {
-        return false;
-      }
+    if (!empty($token['conditions']) && Helpers::areAnyConditionsAClass($token['conditions'])) {
+      return false;
     }
     $phpcsFile->addError(
       "Use of {$staticRefType}%s outside class definition.",
@@ -760,7 +754,7 @@ class VariableAnalysisSniff implements Sniff {
     //   Is an optional function/closure parameter with non-null value
     //   Is closure use declaration of a variable defined within containing scope
     //   catch (...) block start
-    //   $this within a class (but not within a closure).
+    //   $this within a class.
     //   $GLOBALS, $_REQUEST, etc superglobals.
     //   $var part of class::$var static member
     //   Assignment via =

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -199,7 +199,10 @@ class VariableAnalysisTest extends BaseTestCase {
     );
     $phpcsFile->process();
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
-    $expectedErrors = [];
+    $expectedErrors = [
+      58,
+      70,
+    ];
     $this->assertEquals($expectedErrors, $lines);
   }
 
@@ -227,6 +230,7 @@ class VariableAnalysisTest extends BaseTestCase {
       27,
       28,
       35,
+      64,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -199,9 +199,7 @@ class VariableAnalysisTest extends BaseTestCase {
     );
     $phpcsFile->process();
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
-    $expectedErrors = [
-      50,
-    ];
+    $expectedErrors = [];
     $this->assertEquals($expectedErrors, $lines);
   }
 

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithClosureFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithClosureFixture.php
@@ -52,3 +52,33 @@ class ClassWithSelfInsideClosure {
         echo self::$static_member;
     }
 }
+
+function function_with_self_in_closure() {
+    return function() {
+        return self::$foobar; // should be an error
+    }
+}
+
+function function_with_this_in_closure() {
+    return function() {
+        return $this->$foobar; // should be an error
+    }
+}
+
+function function_with_static_in_closure() {
+    return function() {
+        return static::$foobar; // should be an error
+    }
+}
+
+class ClassWithStaticInsideClosure {
+    static $static_member;
+
+    function method_with_self_inside_closure() {
+        echo static::$static_member;
+        array_map(function () {
+                echo static::$static_member;
+            }, array());
+        echo static::$static_member;
+    }
+}


### PR DESCRIPTION
Since this sniff has a minimum version of PHP 5.4 and in that version PHP will autobind `self` inside class method closures, this disables errors for those cases.

Fixes #68 