### PR TITLE
allow self and static references in trait

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -53,7 +53,7 @@ class Helpers {
 
   public static function areAnyConditionsAClass(array $conditions) {
     foreach (array_reverse($conditions, true) as $scopePtr => $scopeCode) {
-      if ($scopeCode === T_CLASS) {
+      if ($scopeCode === T_CLASS || $scopeCode === T_TRAIT) {
         return true;
       }
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -140,6 +140,15 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedErrors, $lines);
   }
 
+  public function testTraitWithMembersErrors() {
+    $fixtureFile = $this->getFixture('TraitWithMembersFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
+    $expectedErrors = [];
+    $this->assertEquals($expectedErrors, $lines);
+  }
+
   public function testClassWithMembersWarnings() {
     $fixtureFile = $this->getFixture('ClassWithMembersFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -145,7 +145,20 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
-    $expectedErrors = [];
+    $expectedErrors = [
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      18,
+      19,
+      64,
+    ];
     $this->assertEquals($expectedErrors, $lines);
   }
 

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -140,11 +140,11 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedErrors, $lines);
   }
 
-  public function testTraitWithMembersErrors() {
+  public function testTraitWithMembersWarnings() {
     $fixtureFile = $this->getFixture('TraitWithMembersFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->process();
-    $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedErrors = [];
     $this->assertEquals($expectedErrors, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/TraitWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/TraitWithMembersFixture.php
@@ -1,0 +1,69 @@
+<?php
+
+trait TraitWithoutMembers {
+    function method_without_param() {
+        echo $var;
+        echo "xxx $var xxx";
+        echo "xxx {$var} xxx";
+        echo "xxx $var $var2 xxx";
+        echo "xxx {$var} {$var2} xxx";
+        func($var);
+        func(12, $var);
+        func($var, 12);
+        func(12, $var, 12);
+        $var = 'set the var';
+        echo $var;
+        echo "xxx $var xxx";
+        echo "xxx {$var} xxx";
+        echo "xxx $var $var2 xxx";
+        echo "xxx {$var} {$var2} xxx";
+        func($var);
+        func(12, $var);
+        func($var, 12);
+        func(12, $var, 12);
+        $this->method_with_member_var();
+        return $var;
+    }
+
+    function method_with_param($param) {
+        echo $param;
+        echo "xxx $param xxx";
+        echo "xxx {$param} xxx";
+        $param = 'set the param';
+        echo $param;
+        echo "xxx $param xxx";
+        echo "xxx {$param} xxx";
+        $this->method_with_member_var();
+        return $param;
+    }
+
+    function method_with_member_var() {
+        echo $this->member_var;
+        echo self::$static_member_var;
+    }
+}
+
+trait TraitWithMembers {
+    public $member_var;
+    static $static_member_var;
+
+    function method_with_member_var() {
+        echo $this->member_var;
+        echo $this->no_such_member_var;
+        echo self::$static_member_var;
+        echo self::$no_such_static_member_var;
+        echo SomeOtherClass::$external_static_member_var;
+    }
+}
+
+trait TraitWithLateStaticBinding {
+    public static $static_member_var;
+
+    static function method_with_late_static_binding($param) {
+        static::some_method($param);
+        static::some_method($var); // should report a warning
+        static::some_method(static::CONSTANT, $param);
+        $called_class = get_called_class();
+        echo $called_class::$static_member_var;
+    }
+}


### PR DESCRIPTION
Maybe I'm missing something since I can hardly believe I'm the first one to encounter this issue. But it seems `self::` and `static::` are not allowed in traits.

This pr fixes that