### PR TITLE
Add checks for class properties

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -346,6 +346,7 @@ class VariableAnalysisSniff implements Sniff {
       T_PUBLIC,
       T_PRIVATE,
       T_PROTECTED,
+      T_VAR,
     ];
     $stopAtPtr = $stackPtr - 2;
     $visibilityPtr = $phpcsFile->findPrevious($propertyDeclarationKeywords, $stackPtr - 1, $stopAtPtr > 0 ? $stopAtPtr : 0);

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -157,7 +157,7 @@ class VariableAnalysisTest extends BaseTestCase {
       13,
       18,
       19,
-      64,
+      66,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -534,7 +534,9 @@ class VariableAnalysisTest extends BaseTestCase {
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
     $phpcsFile->process();
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
-    $expectedWarnings = [];
+    $expectedWarnings = [
+      17,
+    ];
     $this->assertEquals($expectedWarnings, $lines);
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
     $expectedErrors = [];

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassFixture.php
@@ -1,11 +1,15 @@
 <?php
 
-new class {
-    public function sayHelloWorld() {
-        echo 'Hello'.$this->getWorld();
-    }
+class ClassWithAnonymousClass {
+    public function getMyClass() {
+        return new class {
+            public function sayHelloWorld() {
+                echo 'Hello'.$this->getWorld();
+            }
 
-    protected function getWorld() {
-        return ' World!';
+            protected function getWorld() {
+                return ' World!';
+            }
+        };
     }
-};
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -4,9 +4,11 @@ class ClassWithAnonymousClass {
     public function getAnonymousClass() {
         return new class {
             protected $storedHello;
-            private static $storedHello;
-            private $storedHello;
+            private static $storedHello2;
+            private $storedHello3;
             public $helloOptions = [];
+            static $aStaticOne;
+            var $aVarOne;
             public function sayHelloWorld() {
                 echo "hello world";
             }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -1,10 +1,13 @@
 <?php
 
-new class {
-    protected $storedHello;
-    public $helloOptions = [];
-    public function sayHelloWorld() {
-        echo "hello world";
+class ClassWithAnonymousClass {
+    public function getAnonymousClass() {
+        return new class {
+            protected $storedHello;
+            public $helloOptions = [];
+            public function sayHelloWorld() {
+                echo "hello world";
+            }
+        };
     }
-};
-
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -12,6 +12,10 @@ class ClassWithAnonymousClass {
             public function sayHelloWorld() {
                 echo "hello world";
             }
+
+            public function methodWithStaticVar() {
+                static $myStaticVar; // should trigger unused warning
+            }
         };
     }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -4,6 +4,8 @@ class ClassWithAnonymousClass {
     public function getAnonymousClass() {
         return new class {
             protected $storedHello;
+            private static $storedHello;
+            private $storedHello;
             public $helloOptions = [];
             public function sayHelloWorld() {
                 echo "hello world";

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -45,6 +45,8 @@ class ClassWithoutMembers {
 
 class ClassWithMembers {
     public $member_var;
+    private $private_member_var;
+    protected $protected_member_var;
     static $static_member_var;
 
     function method_with_member_var() {


### PR DESCRIPTION
Prior to now, the sniff was treating class property declarations as regular variable declarations in some cases and property reads in other cases. I think this was causing some odd bugs, like #75.

This PR adds an explicit check for class property declarations (using `public`, `private`, `protected`, `var`, `static`, or `public static`, etc.) and ignores them.

Fixes #75 