### PR TITLE
Improve check for static var defs inside functions

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -60,6 +60,21 @@ class Helpers {
     return false;
   }
 
+  public static function areConditionsWithinFunctionBeforeClass(array $conditions) {
+    // Return true if the token conditions are within a function before
+    // they are within a class.
+    $classTypes = [T_CLASS, T_ANON_CLASS, T_TRAIT];
+    foreach (array_reverse($conditions, true) as $scopePtr => $scopeCode) {
+      if (in_array($scopeCode, $classTypes)) {
+        return false;
+      }
+      if ($scopeCode === T_FUNCTION) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static function findPreviousFunctionPtr(File $phpcsFile, $openPtr) {
     // Function names are T_STRING, and return-by-reference is T_BITWISE_AND,
     // so we look backwards from the opening bracket for the first thing that

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -367,7 +367,7 @@ class VariableAnalysisSniff implements Sniff {
     // assuming it's a property.
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];
-    if ($token && !empty($token['conditions']) && end($token['conditions']) !== T_FUNCTION) {
+    if ($token && !empty($token['conditions']) && !Helpers::areConditionsWithinFunctionBeforeClass($token['conditions'])) {
       return Helpers::areAnyConditionsAClass($token['conditions']);
     }
     return false;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -97,4 +97,14 @@ class ClassWithAssignedMembers {
             echo 'it is null';
         }
     }
+
+    function method_with_static_assigned_var_inside_block() {
+        $bool = true;
+        if ($bool === true) {
+            static $new_var = null;
+            if ($new_var === null) {
+                echo 'it is null';
+            }
+        }
+    }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -2,21 +2,21 @@
 
 class ClassWithoutMembers {
     function method_without_param() {
-        echo $var;
-        echo "xxx $var xxx";
-        echo "xxx {$var} xxx";
-        echo "xxx $var $var2 xxx";
-        echo "xxx {$var} {$var2} xxx";
-        func($var);
-        func(12, $var);
-        func($var, 12);
-        func(12, $var, 12);
+        echo $var; // this should be a warning
+        echo "xxx $var xxx"; // this should be a warning
+        echo "xxx {$var} xxx"; // this should be a warning
+        echo "xxx $var $var2 xxx"; // this should be a warning
+        echo "xxx {$var} {$var2} xxx"; // this should be a warning
+        func($var); // this should be a warning
+        func(12, $var); // this should be a warning
+        func($var, 12); // this should be a warning
+        func(12, $var, 12); // this should be a warning
         $var = 'set the var';
         echo $var;
         echo "xxx $var xxx";
         echo "xxx {$var} xxx";
-        echo "xxx $var $var2 xxx";
-        echo "xxx {$var} {$var2} xxx";
+        echo "xxx $var $var2 xxx"; // this should be a warning
+        echo "xxx {$var} {$var2} xxx"; // this should be a warning
         func($var);
         func(12, $var);
         func($var, 12);
@@ -63,7 +63,7 @@ class ClassWithLateStaticBinding {
 
     static function method_with_late_static_binding($param) {
         static::some_method($param);
-        static::some_method($var); // should report a warning
+        static::some_method($var); // should report a warning // this should be a warning
         static::some_method(static::CONSTANT, $param);
         $called_class = get_called_class();
         echo $called_class::$static_member_var;
@@ -74,5 +74,27 @@ class ChildClassWithMembers extends ClassWithMembers {
     function method_with_parent_reference() {
         echo self::$static_member_var;
         echo parent::$no_such_static_member_var;
+    }
+}
+
+class ClassWithAssignedMembers {
+    public $member_var = 'hello';
+    private $private_member_var = 'hi';
+    protected $protected_member_var = 'foo';
+    static $static_member_var = 'bar';
+
+    function method_with_member_var() {
+        echo $this->member_var;
+        echo $this->no_such_member_var;
+        echo self::$static_member_var;
+        echo self::$no_such_static_member_var;
+        echo SomeOtherClass::$external_static_member_var;
+    }
+
+    function method_with_static_assigned_member_var() {
+        static $new_var = null;
+        if ($new_var === null) {
+            echo 'it is null';
+        }
     }
 }


### PR DESCRIPTION
When trying to determine if a static keyword is being used to define a static
class property or a static variable, we were checking only to see if the
enclosing block was a function. However, if the enclosing block is (for
example) an if statement inside a function, then this check would fail when it
should pass.

This change instead checks for any enclosing function, so long as the enclosing
function comes before the enclosing class (to prevent false positives when a
function returns an anonymous class).

Fixes #79 