### PR TITLE
Recognize that variable vars are not assignments

### DIFF
--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -540,6 +540,30 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedErrors, $lines);
   }
 
+  public function testVariableVariables() {
+    $fixtureFile = $this->getFixture('VariableVariablesFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      10,
+      16,
+      22,
+      29,
+      35,
+      41,
+      47,
+      48,
+      52,
+      53,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+    $lines = $this->getErrorLineNumbersFromFile($phpcsFile);
+    $expectedErrors = [];
+    $this->assertEquals($expectedErrors, $lines);
+  }
+
   public function testTraitsAllowPropertyDefinitions() {
     $fixtureFile = $this->getFixture('TraitWithPropertiesFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/VariableVariablesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/VariableVariablesFixture.php
@@ -1,0 +1,56 @@
+<?php
+
+function usedVariableVariableInReturn() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    return $$varName;
+}
+
+function usedVariableVariableInEcho() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    echo $$varName;
+}
+
+function usedVariableVariableInLeftAssignment() {
+    $foo = true; // the below is assignment, not a read, so this should be a warning
+    $marName = 'foo';
+    $$marName = false;
+}
+
+function usedVariableVariableInRightAssignment() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    $bar = $$varName;
+    echo $bar;
+}
+
+function usedVariableVariableInEchoWithBraces() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    echo ${$varName};
+}
+
+function usedVariableVariableInLeftAssignmentWithBraces() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    ${$varName} = false;
+}
+
+function usedVariableVariableInEchoWithBracesInString() {
+    $foo = true; // this is used but it requires execution to know that
+    $varName = 'foo';
+    echo "${$varName}";
+}
+
+function undefinedVariableVariableInEcho() {
+    $foo = true; // this should be a warning
+    echo $$varName; // this should be a warning
+}
+
+function usedVariableVariableTwoLevels() {
+    $foo = 'hello'; // this is used but it requires execution to know that
+    $varNameOne = 'foo'; // this is used but it requires execution to know that
+    $varNameTwo = 'varNameOne';
+    return $$$varNameTwo;
+}


### PR DESCRIPTION
When a variable variable is used as the left side of an assignment, there are actually two variables being checked: there is the current one, and the variable one whose name is the value of the current one.

In this case, we must not treat the current one as an assignment; it is actually a read. This change updates the logic so that this is the case.

Fixes #84 

This does not address the issue that variable variables are not marked as used (see #87).