### PR TITLE
Consider `get_defined_vars()` to be a read

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -83,6 +83,12 @@ class Helpers {
     return $phpcsFile->findPrevious($functionPtrTypes, $openPtr - 1, null, true, null, true);
   }
 
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return int|false
+   */
   public static function findFunctionCall(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
@@ -197,6 +203,12 @@ class Helpers {
     return false;
   }
 
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return int|false
+   */
   public static function findVariableScope(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -3,7 +3,6 @@
 namespace VariableAnalysis\Lib;
 
 use PHP_CodeSniffer\Files\File;
-use VariableAnalysis\Lib\VariableInfo;
 
 class Helpers {
   public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -777,7 +777,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Are we pass-by-reference to known pass-by-reference function?
     $functionPtr = Helpers::findFunctionCall($phpcsFile, $stackPtr);
-    if ($functionPtr === false) {
+    if ($functionPtr === false || ! isset($tokens[$functionPtr])) {
       return false;
     }
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -135,11 +135,21 @@ class VariableAnalysisSniff implements Sniff {
     return ($this->currentFile ? $this->currentFile->getFilename() : 'unknown file') . ':' . $currScope;
   }
 
+  /**
+   * @param int $currScope
+   *
+   * @return ?ScopeInfo
+   */
   protected function getScopeInfo($currScope) {
     $scopeKey = $this->getScopeKey($currScope);
     return isset($this->scopes[$scopeKey]) ? $this->scopes[$scopeKey] : null;
   }
 
+  /**
+   * @param int $currScope
+   *
+   * @return ScopeInfo
+   */
   protected function getOrCreateScopeInfo($currScope) {
     $scopeKey = $this->getScopeKey($currScope);
     if (!isset($this->scopes[$scopeKey])) {
@@ -241,6 +251,13 @@ class VariableAnalysisSniff implements Sniff {
     $varInfo->firstDeclared = $stackPtr;
   }
 
+  /**
+   * @param string $varName
+   * @param int $stackPtr
+   * @param int $currScope
+   *
+   * @return void
+   */
   protected function markVariableRead($varName, $stackPtr, $currScope) {
     $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
     if (isset($varInfo->firstRead) && ($varInfo->firstRead <= $stackPtr)) {

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -905,6 +905,7 @@ class VariableAnalysisTest extends BaseTestCase {
 			6,
 			18,
 			22,
+			29,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -895,4 +895,17 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testGetDefinedVarsCountsAsRead() {
+    $fixtureFile = $this->getFixture('GetDefinedVarsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($this->getSniffFiles(), $fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+			6,
+			18,
+			22,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
@@ -23,3 +23,9 @@ function send_vars_to_method_with_scope_import( $object, $data ) {
         $object->continue_things( get_defined_vars() );
     }, $data );
 }
+
+function send_var_with_var_named_get_defined_vars( $object, $data ) {
+    $get_defined_vars = 'hi';
+    $new_data = $object->transform_data( $data ); // should be a warning
+    $object->continue_things( $get_defined_vars );
+}

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
@@ -1,0 +1,25 @@
+<?php
+
+function send_vars_to_method( $object, $data ) {
+    $some_number = 4;
+    $some_string = 'hello';
+    echo $undefined_data; // should be a warning
+    $new_data = $object->transform_data( $data );
+    $object->continue_things( get_defined_vars() );
+}
+
+function send_vars_to_method_with_global( $object, $data ) {
+    global $global_data;
+    $new_data = $object->transform_data( $data );
+    $object->continue_things( get_defined_vars() );
+}
+
+function send_vars_to_method_with_scope_import( $object, $data ) {
+    $unused_data = 42; // should be a warning
+    $imported_data = 76;
+    return array_map( function( $datum ) use ( $object, $imported_data ) {
+        $new_data = $object->transform_data( $datum );
+        echo $undefined_data; // should be a warning
+        $object->continue_things( get_defined_vars() );
+    }, $data );
+}


### PR DESCRIPTION
When `get_defined_vars()` is called, it should count as a read (a usage) of all the variables in the current scope.

Fixes #91 