### PR TITLE
Refactor methods to have nullable return types

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -296,7 +296,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|false
+   * @return ?int
    */
   public static function findVariableScope(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -321,7 +321,7 @@ class Helpers {
 
     if ($in_class) {
       // Member var of a class, we don't care.
-      return false;
+      return null;
     }
 
     // File scope, hmm, lets use first token of file?

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -249,19 +249,17 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function isNextThingAnAssign(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     // Is the next non-whitespace an assignment?
     $nextPtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, true);
-    if ($nextPtr !== false) {
-      if ($tokens[$nextPtr]['code'] === T_EQUAL) {
-        return $nextPtr;
-      }
+    if (is_int($nextPtr) && $tokens[$nextPtr]['code'] === T_EQUAL) {
+      return $nextPtr;
     }
-    return false;
+    return null;
   }
 
   /**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -251,7 +251,7 @@ class Helpers {
    *
    * @return ?int
    */
-  public static function isNextThingAnAssign(File $phpcsFile, $stackPtr) {
+  public static function getNextAssignPointer(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     // Is the next non-whitespace an assignment?

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -167,7 +167,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return array[]|false
+   * @return array[]
    */
   public static function findFunctionCallArguments(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -177,18 +177,18 @@ class Helpers {
       // Assume $stackPtr is something within the brackets, find our function call
       $stackPtr = Helpers::findFunctionCall($phpcsFile, $stackPtr);
       if ($stackPtr === null) {
-        return false;
+        return [];
       }
     }
 
     // $stackPtr is the function name, find our brackets after it
     $openPtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, true);
     if (($openPtr === false) || ($tokens[$openPtr]['code'] !== T_OPEN_PARENTHESIS)) {
-      return false;
+        return [];
     }
 
     if (!isset($tokens[$openPtr]['parenthesis_closer'])) {
-      return false;
+        return [];
     }
     $closePtr = $tokens[$openPtr]['parenthesis_closer'];
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -6,28 +6,37 @@ use PHP_CodeSniffer\Files\File;
 
 class Helpers {
   /**
-   * @param File $phpcsFile
-   * @param int $stackPtr
+   * @param int|bool $value
    *
-   * @return int|bool
+   * @return ?int
    */
-  public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {
-    $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
-    return $phpcsFile->findPrevious(T_OPEN_SHORT_ARRAY, $stackPtr - 1, $previousStatementPtr);
+  public static function getIntOrNull($value) {
+    return is_int($value) ? $value: null;
   }
 
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
+   */
+  public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {
+    $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
+    return self::getIntOrNull($phpcsFile->findPrevious(T_OPEN_SHORT_ARRAY, $stackPtr - 1, $previousStatementPtr));
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return ?int
    */
   public static function findContainingClosingSquareBracket(File $phpcsFile, $stackPtr) {
-    $endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1);
-    if (is_bool($endOfStatementPtr)) {
-      return false;
+    $endOfStatementPtr = self::getIntOrNull($phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1));
+    if (! $endOfStatementPtr) {
+      return null;
     }
-    return $phpcsFile->findNext(T_CLOSE_SHORT_ARRAY, $stackPtr + 1, $endOfStatementPtr);
+    return self::getIntOrNull($phpcsFile->findNext(T_CLOSE_SHORT_ARRAY, $stackPtr + 1, $endOfStatementPtr));
   }
 
   /**
@@ -45,7 +54,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function findContainingOpeningBracket(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -53,17 +62,17 @@ class Helpers {
       $openPtrs = array_keys($tokens[$stackPtr]['nested_parenthesis']);
       return (int)end($openPtrs);
     }
-    return false;
+    return null;
   }
 
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function findParenthesisOwner(File $phpcsFile, $stackPtr) {
-    return $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+    return self::getIntOrNull($phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true));
   }
 
   /**
@@ -123,7 +132,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $openPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function findPreviousFunctionPtr(File $phpcsFile, $openPtr) {
     // Function names are T_STRING, and return-by-reference is T_BITWISE_AND,
@@ -131,14 +140,14 @@ class Helpers {
     // isn't a function name, reference sigil or whitespace and check if it's a
     // function keyword.
     $functionPtrTypes = [T_STRING, T_WHITESPACE, T_BITWISE_AND];
-    return $phpcsFile->findPrevious($functionPtrTypes, $openPtr - 1, null, true, null, true);
+    return self::getIntOrNull($phpcsFile->findPrevious($functionPtrTypes, $openPtr - 1, null, true, null, true));
   }
 
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function findFunctionCall(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -147,11 +156,11 @@ class Helpers {
     if (is_int($openPtr)) {
       // First non-whitespace thing and see if it's a T_STRING function name
       $functionPtr = $phpcsFile->findPrevious(T_WHITESPACE, $openPtr - 1, null, true, null, true);
-      if ($tokens[$functionPtr]['code'] === T_STRING) {
+      if (is_int($functionPtr) && $tokens[$functionPtr]['code'] === T_STRING) {
         return $functionPtr;
       }
     }
-    return false;
+    return null;
   }
 
   /**
@@ -167,7 +176,7 @@ class Helpers {
     if (($tokens[$stackPtr]['code'] !== T_STRING) && ($tokens[$stackPtr]['code'] !== T_ARRAY)) {
       // Assume $stackPtr is something within the brackets, find our function call
       $stackPtr = Helpers::findFunctionCall($phpcsFile, $stackPtr);
-      if ($stackPtr === false) {
+      if ($stackPtr === null) {
         return false;
       }
     }
@@ -220,7 +229,7 @@ class Helpers {
     $commaPtr = $phpcsFile->findNext(T_COMMA, $stackPtr + 1, null, false, null, true);
     $closePtr = false;
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
-    if ($openPtr !== false) {
+    if ($openPtr !== null) {
       if (isset($tokens[$openPtr]['parenthesis_closer'])) {
         $closePtr = $tokens[$openPtr]['parenthesis_closer'];
       }
@@ -279,7 +288,7 @@ class Helpers {
       return false;
     }
     $functionPtr = Helpers::findPreviousFunctionPtr($phpcsFile, $openPtr);
-    if (($functionPtr !== false) && ($tokens[$functionPtr]['code'] === T_FUNCTION)) {
+    if (($functionPtr !== null) && ($tokens[$functionPtr]['code'] === T_FUNCTION)) {
       return $functionPtr;
     }
     return false;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -276,20 +276,20 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return int|bool
+   * @return ?int
    */
   public static function findFunctionPrototype(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
     if (! is_int($openPtr)) {
-      return false;
+      return null;
     }
     $functionPtr = Helpers::findPreviousFunctionPtr($phpcsFile, $openPtr);
     if (($functionPtr !== null) && ($tokens[$functionPtr]['code'] === T_FUNCTION)) {
       return $functionPtr;
     }
-    return false;
+    return null;
   }
 
   /**

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -195,14 +195,11 @@ class VariableAnalysisSniff implements Sniff {
   }
 
   /**
-   * @param int|bool $currScope
+   * @param int $currScope
    *
    * @return string
    */
   protected function getScopeKey($currScope) {
-    if ($currScope === false) {
-      $currScope = 'file';
-    }
     return ($this->currentFile ? $this->currentFile->getFilename() : 'unknown file') . ':' . $currScope;
   }
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -469,7 +469,7 @@ class VariableAnalysisSniff implements Sniff {
     // T_FUNCTION, but AbstractVariableSniff and AbstractScopeSniff define everything
     // we need to do that as private or final, so we have to do it this hackish way.
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
-    if (is_bool($openPtr)) {
+    if (! is_int($openPtr)) {
       return false;
     }
 
@@ -574,7 +574,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Are we a catch block parameter?
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
-    if ($openPtr === false) {
+    if ($openPtr === null) {
       return false;
     }
 
@@ -787,7 +787,7 @@ class VariableAnalysisSniff implements Sniff {
   protected function checkForListShorthandAssignment(File $phpcsFile, $stackPtr, $varName, $currScope) {
     // OK, are we within a [ ... ] construct?
     $openPtr = Helpers::findContainingOpeningSquareBracket($phpcsFile, $stackPtr);
-    if ($openPtr === false) {
+    if (! is_int($openPtr)) {
       return false;
     }
 
@@ -820,7 +820,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // OK, are we within a list (...) construct?
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
-    if ($openPtr === false) {
+    if ($openPtr === null) {
       return false;
     }
 
@@ -1000,7 +1000,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Are we pass-by-reference to known pass-by-reference function?
     $functionPtr = Helpers::findFunctionCall($phpcsFile, $stackPtr);
-    if ($functionPtr === false || ! isset($tokens[$functionPtr])) {
+    if ($functionPtr === null || ! isset($tokens[$functionPtr])) {
       return false;
     }
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -442,7 +442,7 @@ class VariableAnalysisSniff implements Sniff {
    */
   protected function markAllVariablesRead(File $phpcsFile, $stackPtr) {
     $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-    if (! $currScope) {
+    if ($currScope === null) {
       return;
     }
     $scopeInfo = $this->getOrCreateScopeInfo($currScope);
@@ -1091,7 +1091,7 @@ class VariableAnalysisSniff implements Sniff {
     $varName = Helpers::normalizeVarName($token['content']);
     Helpers::debug('examining token ' . $varName);
     $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-    if ($currScope === false) {
+    if ($currScope === null) {
       Helpers::debug('no scope found');
       return;
     }
@@ -1236,7 +1236,7 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-    if (! $currScope) {
+    if ($currScope === null) {
       return;
     }
     foreach ($matches[1] as $varName) {
@@ -1322,7 +1322,7 @@ class VariableAnalysisSniff implements Sniff {
    */
   protected function processCompact(File $phpcsFile, $stackPtr) {
     $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-    if (! $currScope) {
+    if ($currScope === null) {
       return;
     }
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -487,7 +487,7 @@ class VariableAnalysisSniff implements Sniff {
         $varInfo->passByReference = true;
       }
       //  Are we optional with a default?
-      if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== null) {
+      if (Helpers::getNextAssignPointer($phpcsFile, $stackPtr) !== null) {
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
       }
       return true;
@@ -736,7 +736,7 @@ class VariableAnalysisSniff implements Sniff {
    */
   protected function checkForAssignment(File $phpcsFile, $stackPtr, $varName, $currScope) {
     // Is the next non-whitespace an assignment?
-    $assignPtr = Helpers::isNextThingAnAssign($phpcsFile, $stackPtr);
+    $assignPtr = Helpers::getNextAssignPointer($phpcsFile, $stackPtr);
     if (! is_int($assignPtr)) {
       return false;
     }
@@ -796,7 +796,7 @@ class VariableAnalysisSniff implements Sniff {
     if (! is_int($closePtr)) {
       return false;
     }
-    $assignPtr = Helpers::isNextThingAnAssign($phpcsFile, $closePtr);
+    $assignPtr = Helpers::getNextAssignPointer($phpcsFile, $closePtr);
     if (! is_int($assignPtr)) {
       return false;
     }
@@ -831,7 +831,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // OK, we're a list (...) construct... are we being assigned to?
     $closePtr = $tokens[$openPtr]['parenthesis_closer'];
-    $assignPtr = Helpers::isNextThingAnAssign($phpcsFile, $closePtr);
+    $assignPtr = Helpers::getNextAssignPointer($phpcsFile, $closePtr);
     if (! is_int($assignPtr)) {
       return false;
     }
@@ -927,7 +927,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // It's a static declaration.
     $this->markVariableDeclaration($varName, 'static', null, $stackPtr, $currScope);
-    if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== null) {
+    if (Helpers::getNextAssignPointer($phpcsFile, $stackPtr) !== null) {
       $this->markVariableAssignment($varName, $stackPtr, $currScope);
     }
     return true;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1012,9 +1012,6 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     $argPtrs = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);
-    if ($argPtrs === false) {
-      return false;
-    }
 
     // We're within a function call arguments list, find which arg we are.
     $argPos = false;
@@ -1287,9 +1284,7 @@ class VariableAnalysisSniff implements Sniff {
       if ($argument_first_token['code'] === T_ARRAY) {
         // It's an array argument, recurse.
         $array_arguments = Helpers::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
-        if ($array_arguments !== false) {
-          $this->processCompactArguments($phpcsFile, $stackPtr, $array_arguments, $currScope);
-        }
+        $this->processCompactArguments($phpcsFile, $stackPtr, $array_arguments, $currScope);
         continue;
       }
       if (count($argumentPtrs) > 1) {
@@ -1332,9 +1327,7 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     $arguments = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);
-    if ($arguments !== false) {
-      $this->processCompactArguments($phpcsFile, $stackPtr, $arguments, $currScope);
-    }
+    $this->processCompactArguments($phpcsFile, $stackPtr, $arguments, $currScope);
   }
 
   /**

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -487,7 +487,7 @@ class VariableAnalysisSniff implements Sniff {
         $varInfo->passByReference = true;
       }
       //  Are we optional with a default?
-      if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== false) {
+      if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== null) {
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
       }
       return true;
@@ -927,7 +927,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // It's a static declaration.
     $this->markVariableDeclaration($varName, 'static', null, $stackPtr, $currScope);
-    if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== false) {
+    if (Helpers::isNextThingAnAssign($phpcsFile, $stackPtr) !== null) {
       $this->markVariableAssignment($varName, $stackPtr, $currScope);
     }
     return true;


### PR DESCRIPTION
This shouldn't have any functional change, but it refactors a bunch of methods which currently return a value or `false` to return a value or `null`. Since PHP 7.1 supports nullable return types, this pattern has been shown to be more standard than the ... "falsable" 🤔 return type that I had been using to signal failure.