### PR TITLE
Composer: move PHPCS dependency to `require`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 
 ### Requirements
 
-VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.0.2** or higher.
+VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.1.0** or higher.
 
 ### With PHPCS Composer Installer
 

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
         "phpstan": "./vendor/bin/phpstan analyse -l 7 VariableAnalysis"
     },
     "require" : {
-        "php" : ">=5.6.0"
+        "php" : ">=5.6.0",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "phpunit/phpunit": "^6.5",
         "sirbrillig/phpcs-import-detection": "^1.1",
-        "squizlabs/php_codesniffer": "^3.1",
         "limedeck/phpunit-detailed-printer": "^3.1",
         "phpstan/phpstan": "^0.11.8"
     }


### PR DESCRIPTION
PHPCS is a direct dependency for this utility to be run, so should be in `require`.

The problem with not having it there is that other external /project rulesets may have different PHPCS requirements and Composer will not be able to take the requirements for this project into consideration when doing the version negotiations unless the dependency is explicitly set in `require`.

Relying on PHPCS being installed with the DealerDirect plugin is not stable as they may change their minimum required PHPCS version without notice.

As the minimum version in the `composer.json` file and the one in the `README` were not in line (though very close), I've also updated the minimum required version as mentioned in the `README` to be in line.

**Question**: as the Composer install instructions already suggest using the DealerDirect plugin, why not make that a `no-dev` requirement as well ?