### PR TITLE
PHPCS: document run parameters in project ruleset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - run: COMPOSER=composer.json composer test
       - run: COMPOSER=composer.json composer phpstan
       - run: COMPOSER=composer.json composer lint
-      - run: COMPOSER=composer.json composer lint-self
   build_php5:
     docker:
       - image: circleci/php:5.6.40-zts-stretch-node-browsers-legacy

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "scripts": {
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs",
-        "lint-self": "./vendor/bin/phpcs --standard=./VariableAnalysis",
         "phpstan": "./vendor/bin/phpstan analyse -l 7 VariableAnalysis"
     },
     "require" : {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "prefer-stable": true,
     "scripts": {
         "test": "./vendor/bin/phpunit",
-        "lint": "./vendor/bin/phpcs -s -p VariableAnalysis/Sniffs VariableAnalysis/Lib",
-        "lint-self": "./vendor/bin/phpcs --standard=./VariableAnalysis -s -p VariableAnalysis/Sniffs VariableAnalysis/Lib",
+        "lint": "./vendor/bin/phpcs",
+        "lint-self": "./vendor/bin/phpcs --standard=./VariableAnalysis",
         "phpstan": "./vendor/bin/phpstan analyse -l 7 VariableAnalysis"
     },
     "require" : {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,4 +48,5 @@
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>
     <rule ref="ImportDetection" />
+    <rule ref="VariableAnalysis"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,23 @@
             - bracers on end of line instead new line
             - two space indentation
     </description>
+
+    <file>./VariableAnalysis/</file>
+    <exclude-pattern>./VariableAnalysis/Tests/CodeAnalysis/fixtures/</exclude-pattern>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="sp"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+    <!-- Rules -->
     <rule ref="PSR2">
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />


### PR DESCRIPTION
This makes it easier for contributors to run the PHPCS command for the project.

Includes:
* Adding the `Tests` directory to the run - excluding the test case files in `fixtures`.
* Cleaning up the result report by using the `basepath` configuration.
* Making the run faster by using `parallel` scanning if available,