### PR TITLE
Unit test: fix tests failing

### DIFF
--- a/VariableAnalysis/Tests/BaseTestCase.php
+++ b/VariableAnalysis/Tests/BaseTestCase.php
@@ -36,10 +36,10 @@ class BaseTestCase extends TestCase {
   }
 
   public function getSniffFiles() {
-    return [__DIR__ . '/../../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php'];
+    return [realpath(__DIR__ . '/../../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php')];
   }
 
   public function getFixture($fixtureFilename) {
-    return __DIR__ . '/CodeAnalysis/fixtures/' . $fixtureFilename;
+    return realpath(__DIR__ . '/CodeAnalysis/fixtures/' . $fixtureFilename);
   }
 }


### PR DESCRIPTION
I'm not completely sure why, but when I tried to run the unit tests locally, most were failing.

This minor tweak in how PHPCS is instantiated fixes it. It also removes the need for the `getSniffFiles()` method as there is only one sniff in this standard anyway.