### PR TITLE
Bug fix: recognize use of self/static within anonymous class

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -101,7 +101,7 @@ class Helpers {
    */
   public static function areAnyConditionsAClass(array $conditions) {
     foreach (array_reverse($conditions, true) as $scopePtr => $scopeCode) {
-      if ($scopeCode === T_CLASS || $scopeCode === T_TRAIT) {
+      if ($scopeCode === T_CLASS || $scopeCode === T_ANON_CLASS || $scopeCode === T_TRAIT) {
         return true;
       }
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -580,6 +580,7 @@ class VariableAnalysisTest extends BaseTestCase {
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
       17,
+      38,
     ];
     $this->assertEquals($expectedWarnings, $lines);
     $lines = $this->getErrorLineNumbersFromFile($phpcsFile);

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -15,7 +15,29 @@ class ClassWithAnonymousClass {
 
             public function methodWithStaticVar() {
                 static $myStaticVar; // should trigger unused warning
+
+                echo self::$storedHello;
+                echo static::$storedHello;
             }
         };
     }
 }
+
+$anonClass = new class() {
+    protected $storedHello;
+    private static $storedHello2;
+    private $storedHello3;
+    public $helloOptions = [];
+    static $aStaticOne;
+    var $aVarOne;
+    public function sayHelloWorld() {
+        echo "hello world";
+    }
+
+    public function methodWithStaticVar() {
+        static $myStaticVar; // should trigger unused warning
+
+        echo self::$storedHello;
+        echo static::$storedHello;
+    }
+};


### PR DESCRIPTION
The use of `self::$property`/`static::$property` in non-nested anonymous classes was incorrectly flagged as `SelfOutsideClass`/`StaticOutsideClass` (false positive).

For use within anonymous classes nested within another class, the only reason these weren't flagged was the fact that they were nested.

Fixed now.

Includes unit tests.