### PR TITLE
Composer: update DealerDirect Composer plugin requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5",
         "phpunit/phpunit": "^6.5",
         "sirbrillig/phpcs-import-detection": "^1.1",
         "limedeck/phpunit-detailed-printer": "^3.1",


### PR DESCRIPTION
The DealerDirect Composer plugin released version 0.5.0 over a year ago. Let's allow using it.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.5.0