### PR TITLE
PHPUnit config: add testsuite name

### DIFF
--- a/phpunit.circleci.xml
+++ b/phpunit.circleci.xml
@@ -2,7 +2,7 @@
 	bootstrap="VariableAnalysis/Tests/bootstrap.php"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="VariableAnalysis">
 			<directory>VariableAnalysis/Tests</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 	printerClass="LimeDeck\Testing\Printer"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="VariableAnalysis">
 			<directory>VariableAnalysis/Tests</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
This is a required attribute for PHPUnit 7+ and allowed in older versions.