### PR TITLE
Composer: make the PHPUnit requirements more flexible

### DIFF
--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -35,7 +35,7 @@
         "php" : ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.0 || ^6.5",
         "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5",
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^5.0 || ^6.5",
         "sirbrillig/phpcs-import-detection": "^1.1",
         "limedeck/phpunit-detailed-printer": "^3.1",
         "phpstan/phpstan": "^0.11.8"


### PR DESCRIPTION
... and the same across configs. Composer will sort out which version will actually be installed.