### PR TITLE
Bug fix: false negative unused var

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -3,6 +3,7 @@
 namespace VariableAnalysis\Lib;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class Helpers {
   /**
@@ -256,7 +257,11 @@ class Helpers {
 
     // Is the next non-whitespace an assignment?
     $nextPtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, true);
-    if (is_int($nextPtr) && $tokens[$nextPtr]['code'] === T_EQUAL) {
+    if (is_int($nextPtr)
+      && isset(Tokens::$assignmentTokens[$tokens[$nextPtr]['code']])
+      // Ignore double arrow to prevent triggering on `foreach ( $array as $k => $v )`.
+      && $tokens[$nextPtr]['code'] !== T_DOUBLE_ARROW
+    ) {
       return $nextPtr;
     }
     return null;

--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -923,4 +923,17 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testUnusedVarWithValueChange() {
+    $fixtureFile = $this->getFixture('UnusedVarWithValueChangeFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+            5,
+            8,
+            11,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedVarWithValueChangeFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/UnusedVarWithValueChangeFixture.php
@@ -1,0 +1,18 @@
+<?php
+
+// Issue #111.
+function foo() {
+    $var = 'abc';
+    $var = 'def';
+
+    $var2  = 'def';
+    $var2 .= 'ghi';
+
+    $var3  = 10;
+    $var3 += 20;
+}
+
+// Safeguard that this change doesn't influence (not) reporting on assignments to parameters passed by reference.
+function bar(&$param) {
+	$param .= 'foo';
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
   level: 7
+  reportUnmatchedIgnoredErrors: false
   autoload_files:
     - %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
   paths:


### PR DESCRIPTION
As reported in #111, if a variable is assigned a value with a combined assignment operator, it would not be reported as unused.

Includes unit tests.

Fixes #111