### PR TITLE
PHPStan: document run parameters in project ruleset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "scripts": {
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs",
-        "phpstan": "./vendor/bin/phpstan analyse -l 7 VariableAnalysis"
+        "phpstan": "./vendor/bin/phpstan analyse"
     },
     "require" : {
         "php" : ">=5.6.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,0 @@
-parameters:
-  autoload_files:
-    - %rootDir%/../../../vendor/squizlabs/php_codesniffer/autoload.php
-  excludes_analyse:
-    - */Tests/*
-  ignoreErrors:
-    - '~^Constant T_\w+ not found.$~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+  level: 7
+  autoload_files:
+    - %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
+  paths:
+    - %currentWorkingDirectory%/VariableAnalysis/
+  excludes_analyse:
+    - %currentWorkingDirectory%/VariableAnalysis/Tests/
+  ignoreErrors:
+    - '~^Constant T_\w+ not found.$~'


### PR DESCRIPTION
This makes it easier to run the PHPStan command for the project.

Includes:
* Using `%currentWorkingDirectory%` instead of `%rootdir%`
* Renaming the file to `phpstan.neon.dist` to allow overloading of the config by individual developers.