### PR TITLE
Documentation: minor fixes

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -77,7 +77,7 @@ class Helpers {
 
   /**
    * @param File $phpcsFile
-   * @param int[] $conditions
+   * @param (int|string)[] $conditions
    *
    * @return bool
    */
@@ -95,7 +95,7 @@ class Helpers {
 
 
   /**
-   * @param int[] $conditions
+   * @param (int|string)[] $conditions
    *
    * @return bool
    */
@@ -109,7 +109,7 @@ class Helpers {
   }
 
   /**
-   * @param int[] $conditions
+   * @param (int|string)[] $conditions
    *
    * @return bool
    */

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -105,7 +105,7 @@ class VariableAnalysisSniff implements Sniff {
   public $allowUnusedForeachVariables = true;
 
   /**
-   * @return int[]
+   * @return (int|string)[]
    */
   public function register() {
     return [


### PR DESCRIPTION
Token constants can be integers (native PHP tokens) or strings (PHPCS native tokens and backfilled PHP tokens).