### PR TITLE
Always use array for first arg of findPrevious/Next

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -23,7 +23,7 @@ class Helpers {
    */
   public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr) {
     $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
-    return self::getIntOrNull($phpcsFile->findPrevious(T_OPEN_SHORT_ARRAY, $stackPtr - 1, $previousStatementPtr));
+    return self::getIntOrNull($phpcsFile->findPrevious([T_OPEN_SHORT_ARRAY], $stackPtr - 1, $previousStatementPtr));
   }
 
   /**
@@ -37,7 +37,7 @@ class Helpers {
     if (! $endOfStatementPtr) {
       return null;
     }
-    return self::getIntOrNull($phpcsFile->findNext(T_CLOSE_SHORT_ARRAY, $stackPtr + 1, $endOfStatementPtr));
+    return self::getIntOrNull($phpcsFile->findNext([T_CLOSE_SHORT_ARRAY], $stackPtr + 1, $endOfStatementPtr));
   }
 
   /**
@@ -196,7 +196,7 @@ class Helpers {
     $argPtrs = [];
     $lastPtr = $openPtr;
     $lastArgComma = $openPtr;
-    $nextPtr = $phpcsFile->findNext(T_COMMA, $lastPtr + 1, $closePtr);
+    $nextPtr = $phpcsFile->findNext([T_COMMA], $lastPtr + 1, $closePtr);
     while (is_int($nextPtr)) {
       if (Helpers::findContainingOpeningBracket($phpcsFile, $nextPtr) == $openPtr) {
         // Comma is at our level of brackets, it's an argument delimiter.
@@ -204,7 +204,7 @@ class Helpers {
         $lastArgComma = $nextPtr;
       }
       $lastPtr = $nextPtr;
-      $nextPtr = $phpcsFile->findNext(T_COMMA, $lastPtr + 1, $closePtr);
+      $nextPtr = $phpcsFile->findNext([T_COMMA], $lastPtr + 1, $closePtr);
     }
     array_push($argPtrs, range($lastArgComma + 1, $closePtr - 1));
 
@@ -226,8 +226,8 @@ class Helpers {
     //  However, if we're within a bracketed expression, we take place at the
     //  closing bracket, if that's first.
     //  eg: echo (($var = 12) && ($var == 12));
-    $semicolonPtr = $phpcsFile->findNext(T_SEMICOLON, $stackPtr + 1, null, false, null, true);
-    $commaPtr = $phpcsFile->findNext(T_COMMA, $stackPtr + 1, null, false, null, true);
+    $semicolonPtr = $phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1, null, false, null, true);
+    $commaPtr = $phpcsFile->findNext([T_COMMA], $stackPtr + 1, null, false, null, true);
     $closePtr = false;
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
     if ($openPtr !== null) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -187,7 +187,7 @@ class VariableAnalysisSniff implements Sniff {
       return false;
     }
     // Make sure this is a function call
-    $parenPointer = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, $stackPtr + 2);
+    $parenPointer = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr, $stackPtr + 2);
     if (! $parenPointer) {
       return false;
     }
@@ -500,7 +500,7 @@ class VariableAnalysisSniff implements Sniff {
         return true;
       }
       // $functionPtr is at the use, we need the function keyword for start of scope.
-      $functionPtr = $phpcsFile->findPrevious(T_CLOSURE, $functionPtr - 1, $currScope + 1, false, null, true);
+      $functionPtr = $phpcsFile->findPrevious([T_CLOSURE], $functionPtr - 1, $currScope + 1, false, null, true);
       if (! is_bool($functionPtr)) {
         $this->markVariableDeclaration($varName, 'bound', null, $stackPtr, $functionPtr);
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
@@ -684,7 +684,7 @@ class VariableAnalysisSniff implements Sniff {
     }
     // "When calling static methods, the function call is stronger than the
     // static property operator" so look for a function call.
-    $parenPointer = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, $stackPtr + 2);
+    $parenPointer = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr, $stackPtr + 2);
     if ($parenPointer) {
       return false;
     }


### PR DESCRIPTION
Not sure why phpstan is complaining about this now, but it seems to hink
that T_OPEN_SHORT_ARRAY, etc, are strings rather than integers. Doing
this makes it quiet down.

This should have no real effect.