### PR TITLE
Helper::getNextAssignPointer(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -256,7 +256,7 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
 
     // Is the next non-whitespace an assignment?
-    $nextPtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, true);
+    $nextPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
     if (is_int($nextPtr)
       && isset(Tokens::$assignmentTokens[$tokens[$nextPtr]['code']])
       // Ignore double arrow to prevent triggering on `foreach ( $array as $k => $v )`.

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithInlineAssignFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithInlineAssignFixture.php
@@ -4,7 +4,7 @@ function function_with_inline_assigns() {
     ($var = 12) && $var;
     echo $var;
     echo $var2;
-    while ($var2 = whatever()) {
+    while ($var2 /*comment*/ = whatever()) {
         echo $var2;
     }
     echo $var2;


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.