### PR TITLE
Helper::findParenthesisOwner(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -73,7 +73,7 @@ class Helpers {
    * @return ?int
    */
   public static function findParenthesisOwner(File $phpcsFile, $stackPtr) {
-    return self::getIntOrNull($phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true));
+    return self::getIntOrNull($phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true));
   }
 
   /**

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithForeachFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithForeachFixture.php
@@ -45,7 +45,7 @@ function function_with_defined_foreach() {
         echo "$key2 => $value2\n";
     }
     echo "$key2 => $value2\n";
-    foreach ($array as $element3) {
+    foreach /*comment*/ ($array as $element3) {
     }
     foreach ($array as &$element4) {
     }


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.