### PR TITLE
Helper::findPreviousFunctionPtr(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -140,7 +140,10 @@ class Helpers {
     // so we look backwards from the opening bracket for the first thing that
     // isn't a function name, reference sigil or whitespace and check if it's a
     // function keyword.
-    $functionPtrTypes = [T_STRING, T_WHITESPACE, T_BITWISE_AND];
+    $functionPtrTypes                = Tokens::$emptyTokens;
+    $functionPtrTypes[T_STRING]      = T_STRING;
+    $functionPtrTypes[T_BITWISE_AND] = T_BITWISE_AND;
+
     return self::getIntOrNull($phpcsFile->findPrevious($functionPtrTypes, $openPtr - 1, null, true, null, true));
   }
 

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
@@ -1,5 +1,5 @@
 <?php
-function &function_with_return_by_reference_and_param($param) {
+function /*comment*/ &function_with_return_by_reference_and_param($param) {
     echo $param;
     return $param;
 }


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.