### PR TITLE
Helper::findFunctionCall[Arguments](): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -156,7 +156,7 @@ class Helpers {
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
     if (is_int($openPtr)) {
       // First non-whitespace thing and see if it's a T_STRING function name
-      $functionPtr = $phpcsFile->findPrevious(T_WHITESPACE, $openPtr - 1, null, true, null, true);
+      $functionPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $openPtr - 1, null, true, null, true);
       if (is_int($functionPtr) && $tokens[$functionPtr]['code'] === T_STRING) {
         return $functionPtr;
       }
@@ -183,7 +183,7 @@ class Helpers {
     }
 
     // $stackPtr is the function name, find our brackets after it
-    $openPtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, true);
+    $openPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
     if (($openPtr === false) || ($tokens[$openPtr]['code'] !== T_OPEN_PARENTHESIS)) {
         return [];
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
@@ -44,7 +44,7 @@ function function_with_pass_by_reference_calls() {
     echo $var1;
     echo $var2;
     echo $var3;
-    maxdb_stmt_bind_result($stmt, $var1, $var2, $var3);
+    maxdb_stmt_bind_result /*comment*/ ($stmt, $var1, $var2, $var3);
     echo $var1;
     echo $var2;
     echo $var3;


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.