### PR TITLE
Helper::findVariableScope(): performance tweak

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -313,7 +313,7 @@ class Helpers {
         if (($scopeCode === T_FUNCTION) || ($scopeCode === T_CLOSURE)) {
           return $scopePtr;
         }
-        if (in_array($scopeCode, [T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT])) {
+        if (isset(Tokens::$ooScopeTokens[$scopeCode]) === true) {
           $in_class = true;
         }
       }


### PR DESCRIPTION
Using `isset()` is significantly faster than a call to `in_array()` and as the PHPCS native `Tokens` class already contains a property representing the tokens being checked for here, we may as well use it.