### PR TITLE
Allow running the unit tests on more recent PHPUnit versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /composer.lock
 /vendor/
 phpunit.xml
+.phpunit.result.cache
 .phpcs.xml
 phpcs.xml
 tags

--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -35,7 +35,7 @@
         "php" : ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^6.5",
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
-        "phpunit/phpunit": "^5.0 || ^6.5",
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
         "sirbrillig/phpcs-import-detection": "^1.1",
-        "limedeck/phpunit-detailed-printer": "^3.1",
+        "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
         "phpstan/phpstan": "^0.11.8"
     }
 }


### PR DESCRIPTION
I've tested and the unit tests as-is are compatible with PHPUnit 7.x and 8.x without needing any adjustments, so we may as well allow using/installing those versions.

Includes widening the version requirements for the `limedeck/phpunit-detailed-printer` to prevent it from being a blocker for using more recent PHPUnit versions.

Version 4.x of the `limedeck/phpunit-detailed-printer` is compatible with PHPUnit 7.x, version 5.x is compatible with PHPUnit 8.x.
Ref: https://github.com/LimeDeck/phpunit-detailed-printer/releases