### PR TITLE
CircleCI Composer: move PHPCS dependency to `require`

### DIFF
--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -32,10 +32,10 @@
         "test": "./vendor/bin/phpunit --configuration phpunit.circleci.xml"
     },
     "require" : {
-        "php" : ">=5.6.0"
+        "php" : ">=5.6.0",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0"
     }
 }


### PR DESCRIPTION
Follow up on #106 which did this for the "normal" `composer.json` file.