### PR TITLE
VariableAnalysisSniff::isGetDefinedVars(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -187,8 +188,8 @@ class VariableAnalysisSniff implements Sniff {
       return false;
     }
     // Make sure this is a function call
-    $parenPointer = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr, $stackPtr + 2);
-    if (! $parenPointer) {
+    $parenPointer = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+    if (! $parenPointer || $tokens[$parenPointer]['code'] !== T_OPEN_PARENTHESIS) {
       return false;
     }
     return true;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/GetDefinedVarsFixture.php
@@ -20,7 +20,7 @@ function send_vars_to_method_with_scope_import( $object, $data ) {
     return array_map( function( $datum ) use ( $object, $imported_data ) {
         $new_data = $object->transform_data( $datum );
         echo $undefined_data; // should be a warning
-        $object->continue_things( get_defined_vars() );
+        $object->continue_things( get_defined_vars /* comment */ () );
     }, $data );
 }
 


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.