### PR TITLE
VariableAnalysisSniff::checkForFunctionPrototype(): fix comment tolerance in pass by reference declaration

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -478,7 +479,7 @@ class VariableAnalysisSniff implements Sniff {
     ) {
       $this->markVariableDeclaration($varName, 'param', null, $stackPtr, $functionPtr);
       // Are we pass-by-reference?
-      $referencePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true, null, true);
+      $referencePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true);
       if (($referencePtr !== false) && ($tokens[$referencePtr]['code'] === T_BITWISE_AND)) {
         $varInfo = $this->getOrCreateVariableInfo($varName, $functionPtr);
         $varInfo->passByReference = true;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
@@ -50,7 +50,7 @@ function function_with_pass_by_reference_calls() {
     echo $var3;
 }
 
-function function_with_pass_by_ref_assign_only_arg(&$return_value) {
+function function_with_pass_by_ref_assign_only_arg(&  /*comment*/  $return_value) {
     $return_value = 42;
 }
 


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.