### PR TITLE
VariableAnalysisSniff::checkForFunctionPrototype(): fix comment tolerance in closure use by reference

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -506,7 +507,7 @@ class VariableAnalysisSniff implements Sniff {
         $this->markVariableAssignment($varName, $stackPtr, $functionPtr);
 
         // Are we pass-by-reference?
-        $referencePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true, null, true);
+        $referencePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true);
         if ((! is_bool($referencePtr)) && ($tokens[$referencePtr]['code'] === T_BITWISE_AND)) {
           $varInfo = $this->getOrCreateVariableInfo($varName, $functionPtr);
           $varInfo->passByReference = true;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUseReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithUseReferenceFixture.php
@@ -2,6 +2,6 @@
 
 $ref = 0;
 
-$function_with_use_reference = function () use (&$ref) {
+$function_with_use_reference = function () use (& /*comment */ $ref) {
     $ref = 1;
 };


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.