### PR TITLE
VariableAnalysisSniff::checkForCatchBlock(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -575,7 +576,7 @@ class VariableAnalysisSniff implements Sniff {
       return false;
     }
 
-    $catchPtr = $phpcsFile->findPrevious(T_WHITESPACE, $openPtr - 1, null, true, null, true);
+    $catchPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $openPtr - 1, null, true, null, true);
     if (($catchPtr !== false) && ($tokens[$catchPtr]['code'] === T_CATCH)) {
       // Scope of the exception var is actually the function, not just the catch block.
       $this->markVariableDeclaration($varName, 'local', null, $stackPtr, $currScope, true);

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithTryCatchFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithTryCatchFixture.php
@@ -6,7 +6,7 @@ function function_with_try_catch() {
     try {
         echo $e;
         echo $var;
-    } catch (Exception $e) {
+    } catch /* comment */ (Exception $e) {
         echo $e;
         echo $var;
     }


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.