### PR TITLE
VariableAnalysisSniff::checkForStaticMember(): fix comment tolerance [1]

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -667,11 +668,11 @@ class VariableAnalysisSniff implements Sniff {
   protected function checkForStaticMember(File $phpcsFile, $stackPtr, $varName, $currScope) {
     $tokens = $phpcsFile->getTokens();
 
-    $doubleColonPtr = $stackPtr - 1;
-    if ($tokens[$doubleColonPtr]['code'] !== T_DOUBLE_COLON) {
+    $doubleColonPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+    if ($doubleColonPtr === false || $tokens[$doubleColonPtr]['code'] !== T_DOUBLE_COLON) {
       return false;
     }
-    $classNamePtr = $stackPtr - 2;
+    $classNamePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $doubleColonPtr - 1, null, true);
     $staticReferences = [
       T_STRING,
       T_SELF,
@@ -679,7 +680,7 @@ class VariableAnalysisSniff implements Sniff {
       T_STATIC,
       T_VARIABLE,
     ];
-    if (! in_array($tokens[$classNamePtr]['code'], $staticReferences, true)) {
+    if ($classNamePtr === false || ! in_array($tokens[$classNamePtr]['code'], $staticReferences, true)) {
       return false;
     }
     // "When calling static methods, the function call is stronger than the

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassWithMembersFixture.php
@@ -52,7 +52,7 @@ class ClassWithMembers {
     function method_with_member_var() {
         echo $this->member_var;
         echo $this->no_such_member_var;
-        echo self::$static_member_var;
+        echo self :: $static_member_var;
         echo self::$no_such_static_member_var;
         echo SomeOtherClass::$external_static_member_var;
     }
@@ -73,7 +73,7 @@ class ClassWithLateStaticBinding {
 class ChildClassWithMembers extends ClassWithMembers {
     function method_with_parent_reference() {
         echo self::$static_member_var;
-        echo parent::$no_such_static_member_var;
+        echo parent /*comment*/ :: $no_such_static_member_var;
     }
 }
 
@@ -87,7 +87,7 @@ class ClassWithAssignedMembers {
         echo $this->member_var;
         echo $this->no_such_member_var;
         echo self::$static_member_var;
-        echo self::$no_such_static_member_var;
+        echo self::  /*comment*/  $no_such_static_member_var;
         echo SomeOtherClass::$external_static_member_var;
     }
 


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.