### PR TITLE
VariableAnalysisSniff::checkForStaticMember(): fix comment tolerance [2]

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -684,8 +685,8 @@ class VariableAnalysisSniff implements Sniff {
     }
     // "When calling static methods, the function call is stronger than the
     // static property operator" so look for a function call.
-    $parenPointer = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr, $stackPtr + 2);
-    if ($parenPointer) {
+    $parenPointer = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+    if ($parenPointer !== false && $tokens[$parenPointer]['code'] === T_OPEN_PARENTHESIS) {
       return false;
     }
     return true;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithVariableCallFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithVariableCallFixture.php
@@ -7,7 +7,7 @@ class MyClass {
     }
 
     public function funcUsingSelfCallbackFromArgument($meta, $callback) {
-        return self::$callback( $meta  );
+        return self::$callback /*comment*/ ( $meta  );
     }
 
     public function funcUsingStaticCallbackFromArgument($meta, $callback) {


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.