### PR TITLE
VariableAnalysisSniff::checkForStaticOutsideClass(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -705,11 +706,14 @@ class VariableAnalysisSniff implements Sniff {
     $tokens = $phpcsFile->getTokens();
     $token  = $tokens[$stackPtr];
 
-    $doubleColonPtr = $stackPtr - 1;
-    if ($tokens[$doubleColonPtr]['code'] !== T_DOUBLE_COLON) {
+    $doubleColonPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+    if ($doubleColonPtr === false || $tokens[$doubleColonPtr]['code'] !== T_DOUBLE_COLON) {
       return false;
     }
-    $classNamePtr = $stackPtr - 2;
+    $classNamePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $doubleColonPtr - 1, null, true);
+    if ($classNamePtr === false) {
+      return false;
+    }
     $code = $tokens[$classNamePtr]['code'];
     $staticReferences = [
       T_SELF,

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithClosureFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithClosureFixture.php
@@ -55,7 +55,7 @@ class ClassWithSelfInsideClosure {
 
 function function_with_self_in_closure() {
     return function() {
-        return self::$foobar; // should be an error
+        return self /*comment*/::$foobar; // should be an error
     };
 }
 
@@ -67,7 +67,7 @@ function function_with_this_in_closure() {
 
 function function_with_static_in_closure() {
     return function() {
-        return static::$foobar; // should be an error
+        return static:: /*comment*/ $foobar; // should be an error
     };
 }
 


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.