### PR TITLE
VariableAnalysisSniff::checkForListAssignment(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -843,7 +844,7 @@ class VariableAnalysisSniff implements Sniff {
       return false;
     }
 
-    $prevPtr = $phpcsFile->findPrevious(T_WHITESPACE, $openPtr - 1, null, true, null, true);
+    $prevPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $openPtr - 1, null, true, null, true);
     if (($prevPtr === false) || ($tokens[$prevPtr]['code'] !== T_LIST)) {
       return false;
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/DestructuringFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/DestructuringFixture.php
@@ -9,7 +9,7 @@ function function_with_destructuring_assignment() {
 
 function function_with_destructuring_assignment_using_list() {
     list( $a, $b ) = [1, 2];
-    list( $c, $d ) = [3, 4]; // unused
+    list /* comment */ ( $c, $d ) = [3, 4]; // unused
     echo $a;
     echo $b;
     echo $c;


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.