### PR TITLE
VariableAnalysisSniff::checkForGlobalDeclaration(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -873,8 +874,12 @@ class VariableAnalysisSniff implements Sniff {
     $tokens = $phpcsFile->getTokens();
 
     // Are we a global declaration?
-    // Search backwards for first token that isn't whitespace, comma or variable.
-    $globalPtr = $phpcsFile->findPrevious([T_WHITESPACE, T_VARIABLE, T_COMMA], $stackPtr - 1, null, true, null, true);
+    // Search backwards for first token that isn't whitespace/comment, comma or variable.
+    $ignore             = Tokens::$emptyTokens;
+    $ignore[T_VARIABLE] = T_VARIABLE;
+    $ignore[T_COMMA]    = T_COMMA;
+
+    $globalPtr = $phpcsFile->findPrevious($ignore, $stackPtr - 1, null, true, null, true);
     if (($globalPtr === false) || ($tokens[$globalPtr]['code'] !== T_GLOBAL)) {
       return false;
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithGlobalVarFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithGlobalVarFixture.php
@@ -1,7 +1,7 @@
 <?php
 
 function function_with_global_var() {
-    global $var, $var2, $unused; // should warn that `unused` is unused
+    global $var, /*comment*/ $var2, $unused; // should warn that `unused` is unused
 
     echo $var;
     echo $var3; // should warn that var is undefined


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.