### PR TITLE
VariableAnalysisSniff::checkForSymbolicObjectProperty(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -1086,7 +1087,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Are we a symbolic object property/function derefeference?
     // Search backwards for first token that isn't whitespace, is it a "->" operator?
-    $objectOperatorPtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true, null, true);
+    $objectOperatorPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true);
     if (($objectOperatorPtr === false) || ($tokens[$objectOperatorPtr]['code'] !== T_OBJECT_OPERATOR)) {
       return false;
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/ClassReferenceFixture.php
@@ -8,7 +8,7 @@ class ClassWithSymbolicRefProperty {
             $this->$property = 'some value';
             $this -> $property = 'some value';
             $this->$undefined_property = 'some value';
-            $this -> $undefined_property = 'some value';
+            $this -> /* comment*/ $undefined_property = 'some value';
             $this->$ignored_property = 'some value';
             $this -> $ignored_property = 'some value';
         }


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.