### PR TITLE
VariableAnalysisSniff::processCompactArguments(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -8,6 +8,7 @@ use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableAnalysisSniff implements Sniff {
   /**
@@ -1291,7 +1292,7 @@ class VariableAnalysisSniff implements Sniff {
 
     foreach ($arguments as $argumentPtrs) {
       $argumentPtrs = array_values(array_filter($argumentPtrs, function ($argumentPtr) use ($tokens) {
-        return $tokens[$argumentPtr]['code'] !== T_WHITESPACE;
+        return isset(Tokens::$emptyTokens[$tokens[$argumentPtr]['code']]) === false;
       }));
       if (empty($argumentPtrs)) {
         continue;

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/CompactFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/CompactFixture.php
@@ -6,7 +6,7 @@ function function_with_literal_compact($param1, $param2, $param3, $param4) {
     $squish = compact('var1');
     $squish = compact('var3');
     $squish = compact('param1');
-    $squish = compact('var2', 'param3');
+    $squish = compact('var2', /*comment*/ 'param3');
     $squish = compact(array('var4'), array('param4', 'var5'));
     echo $squish;
 }
@@ -20,10 +20,10 @@ function function_with_expression_compact($param1, $param2, $param3, $param4) {
     $var8 = "value8";
     $var9 = "value9";
     $squish = compact("var1");
-    $squish = compact("var3");
+    $squish = compact("var3"/*comment*/ );
     $squish = compact("param1");
     $squish = compact("var2", "param3");
-    $squish = compact(array("var4"), array("param4", "var5"));
+    $squish = compact(array("var4"), array("param4", /*comment*/ "var5"));
     $squish = compact($var6);
     $squish = compact("var" . "7");
     $squish = compact("blah $var8");


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.