### PR TITLE
VariableAnalysisSniff::checkForAssignment(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -763,9 +763,9 @@ class VariableAnalysisSniff implements Sniff {
 
     // Are we are reference variable?
     $tokens = $tokens = $phpcsFile->getTokens();
-    $referencePtr = $phpcsFile->findNext(T_WHITESPACE, $assignPtr + 1, null, true, null, true);
+    $referencePtr = $phpcsFile->findNext(Tokens::$emptyTokens, $assignPtr + 1, null, true, null, true);
     $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
-    if (($referencePtr !== false) && ($tokens[$referencePtr]['code'] === T_BITWISE_AND)) {
+    if ($referencePtr !== false && $tokens[$referencePtr]['code'] === T_BITWISE_AND) {
       $varInfo->isReference = true;
     } elseif ($varInfo->isReference) {
       // If this is an assigment to a reference variable then that variable is

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/AssignmentByReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/AssignmentByReferenceFixture.php
@@ -15,7 +15,7 @@ class A {
 function usedAssignmentByReference() {
   $a = new A();
 
-  $var = &$a->getProp();
+  $var = /*comment*/ &$a->getProp();
   $var = ['bar'];
   return $a;
 }


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.