### PR TITLE
VariableAnalysisSniff::checkForPassByReferenceFunctionCall(): fix comment tolerance

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1075,7 +1075,7 @@ class VariableAnalysisSniff implements Sniff {
       if ($ptr === $stackPtr) {
         continue;
       }
-      if ($tokens[$ptr]['code'] !== T_WHITESPACE) {
+      if (isset(Tokens::$emptyTokens[$tokens[$ptr]['code']]) === false) {
         return false;
       }
     }

--- a/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/fixtures/FunctionWithReferenceFixture.php
@@ -32,7 +32,7 @@ function function_with_pass_by_reference_calls() {
     echo $matches;
     echo $needle;
     echo $haystack;
-    preg_match('/(abc)/', 'defabcghi', $matches);
+    preg_match('/(abc)/', 'defabcghi', /* comment */ $matches);
     preg_match($needle,   'defabcghi', $matches);
     preg_match('/(abc)/', $haystack,   $matches);
     echo $matches;


### PR DESCRIPTION
PHP ignores comments in unexpected/unconventional places and so should the sniff.

Includes adjusting an existing unit test.

Without the fix, the adjusted unit test would cause test failures.