### PR TITLE
Tests: fix namespace

### DIFF
--- a/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
+++ b/VariableAnalysis/Tests/CodeAnalysis/VariableAnalysisTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace VariableAnalysis\Tests;
+namespace VariableAnalysis\Tests\CodeAnalysis;
 
 use VariableAnalysis\Tests\BaseTestCase;
 


### PR DESCRIPTION
Closes #162

Note: alternatively the choice could be made to move the `Tests` directory out of the `VariableAnalysis` directory as, as this standard doesn't use the PHPCS native test framework, there is no need for the tests to be in the same directory as the application files.