### PR TITLE
Fix unused-before-used detection

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -97,6 +97,7 @@ class VariableAnalysisTest extends BaseTestCase {
       28,
       29,
       39,
+      54,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -766,6 +767,7 @@ class VariableAnalysisTest extends BaseTestCase {
       7,
       23,
       39,
+			54,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -806,6 +808,8 @@ class VariableAnalysisTest extends BaseTestCase {
       8,
       16,
       19,
+      28,
+      34,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -818,6 +822,8 @@ class VariableAnalysisTest extends BaseTestCase {
     $expectedWarnings = [
       8,
       19,
+      28,
+      34,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
@@ -50,3 +50,8 @@ function updateGlobalWithListShorthand($newVal) {
   [ $myGlobal, $otherVar ] = my_function($newVal);
   echo $otherVar;
 }
+
+function globalWithUnusedFunctionArg($user_type, $text, $testvar) { // should warn that testvar is unused
+	global $config;
+	return $config . $text . $user_type;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/UnusedAfterUsedFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/UnusedAfterUsedFixture.php
@@ -23,3 +23,17 @@ function inner_function() {
     };
     $foo();
 }
+
+// The following line should report an unused variable (unused after used)
+function function_with_one_unused_param($used, $used_two, $unused_three) {
+    echo $used;
+    echo $used_two;
+}
+
+// The following line should report an unused variable (unused after used)
+function function_with_local_and_unused_params($used, $used_two, $unused_three) {
+    $foobar = 'hello';
+    echo $used;
+    echo $foobar;
+    echo $used_two;
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -284,6 +284,9 @@ class VariableAnalysisSniff implements Sniff {
       if (! $foundVarPosition) {
         continue;
       }
+      if ($variable->scopeType !== 'param') {
+        continue;
+      }
       if ($variable->firstRead) {
         return true;
       }
@@ -1417,6 +1420,7 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
     if ($this->allowUnusedParametersBeforeUsed && $varInfo->scopeType === 'param' && $this->areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
+      Helpers::debug("variable {$varInfo->name} at end of scope has unused following args");
       return;
     }
     if ($this->allowUnusedForeachVariables && $varInfo->isForeachLoopAssociativeValue) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -526,12 +526,10 @@ class VariableAnalysisSniff implements Sniff {
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
-   * @param string $varName
-   * @param int $currScope
    *
    * @return bool
    */
-  protected function checkForClassProperty(File $phpcsFile, $stackPtr, $varName, $currScope) {
+  protected function checkForClassProperty(File $phpcsFile, $stackPtr) {
     $propertyDeclarationKeywords = [
       T_PUBLIC,
       T_PRIVATE,
@@ -664,12 +662,10 @@ class VariableAnalysisSniff implements Sniff {
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
-   * @param string $varName
-   * @param int $currScope
    *
    * @return bool
    */
-  protected function checkForStaticMember(File $phpcsFile, $stackPtr, $varName, $currScope) {
+  protected function checkForStaticMember(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     $doubleColonPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
@@ -700,11 +696,10 @@ class VariableAnalysisSniff implements Sniff {
    * @param File $phpcsFile
    * @param int $stackPtr
    * @param string $varName
-   * @param int $currScope
    *
    * @return bool
    */
-  protected function checkForStaticOutsideClass(File $phpcsFile, $stackPtr, $varName, $currScope) {
+  protected function checkForStaticOutsideClass(File $phpcsFile, $stackPtr, $varName) {
     // Are we refering to self:: outside a class?
 
     $tokens = $phpcsFile->getTokens();
@@ -756,7 +751,7 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     // Is this a variable variable? If so, it's not an assignment to the current variable.
-    if ($this->checkForVariableVariable($phpcsFile, $stackPtr, $varName, $currScope)) {
+    if ($this->checkForVariableVariable($phpcsFile, $stackPtr)) {
       Helpers::debug('found variable variable');
       return false;
     }
@@ -783,12 +778,10 @@ class VariableAnalysisSniff implements Sniff {
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
-   * @param string $varName
-   * @param int $currScope
    *
    * @return bool
    */
-  protected function checkForVariableVariable(File $phpcsFile, $stackPtr, $varName, $currScope) {
+  protected function checkForVariableVariable(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
     $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
@@ -1201,18 +1194,18 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     // Check for static members used outside a class
-    if ($this->checkForStaticOutsideClass($phpcsFile, $stackPtr, $varName, $currScope)) {
+    if ($this->checkForStaticOutsideClass($phpcsFile, $stackPtr, $varName)) {
       Helpers::debug('found static usage outside of class');
       return;
     }
 
     // $var part of class::$var static member
-    if ($this->checkForStaticMember($phpcsFile, $stackPtr, $varName, $currScope)) {
+    if ($this->checkForStaticMember($phpcsFile, $stackPtr)) {
       Helpers::debug('found static member');
       return;
     }
 
-    if ($this->checkForClassProperty($phpcsFile, $stackPtr, $varName, $currScope)) {
+    if ($this->checkForClassProperty($phpcsFile, $stackPtr)) {
       Helpers::debug('found class property definition');
       return;
     }


### PR DESCRIPTION
The logic in `areFollowingArgumentsUsed` is flawed; it was not limited to just function arguments, so it was also applying to global variables and scoped variables.

Fixes #170 