### PR TITLE
Added property validUndefinedVariableRegexp to VariableAnalysisSniff

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -793,6 +793,25 @@ class VariableAnalysisTest extends BaseTestCase {
     $this->assertEquals($expectedWarnings, $lines);
   }
 
+  public function testValidUndefinedVariableRegexpIgnoresUndefinedProperties() {
+    $fixtureFile = $this->getFixture('ClassReferenceFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUndefinedVariableRegexp',
+      '/^undefined_/'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      12,
+      13,
+      24,
+      25
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
   public function testUnusedArgumentsBeforeUsedArgumentsAreFoundIfFalse() {
     $fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
     $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -91,6 +91,15 @@ class VariableAnalysisSniff implements Sniff {
   public $validUndefinedVariableNames = null;
 
   /**
+   *  A PHP regexp string for variables that you want to ignore from undefined
+   *  variable warnings. For example, to ignore the variables `$_junk` and
+   *  `$_unused`, this could be set to `'/^_/'`.
+   *
+   *  @var string|null
+   */
+  public $validUndefinedVariableRegexp= null;
+
+  /**
    * Allows unused arguments in a function definition if they are
    * followed by an argument which is used.
    *
@@ -262,6 +271,9 @@ class VariableAnalysisSniff implements Sniff {
         $scopeInfo->variables[$varName]->ignoreUnused = true;
       }
       if (in_array($varName, $validUndefinedVariableNames)) {
+        $scopeInfo->variables[$varName]->ignoreUndefined = true;
+      }
+      if (isset($this->validUndefinedVariableRegexp) && preg_match($this->validUndefinedVariableRegexp, $varName) === 1) {
         $scopeInfo->variables[$varName]->ignoreUndefined = true;
       }
     }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -97,7 +97,7 @@ class VariableAnalysisSniff implements Sniff {
    *
    *  @var string|null
    */
-  public $validUndefinedVariableRegexp= null;
+  public $validUndefinedVariableRegexp = null;
 
   /**
    * Allows unused arguments in a function definition if they are


### PR DESCRIPTION
Hi this property is useful for me as in my company they follow a name standard for declaring global variables (I don't like that, but it's annoying to constantly pollute the undeclared warnings with those). Just in case you'd like to include this in the master branch. Thanks for this great project BTW.