### PR TITLE
Throw an error if phpcsutils is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 
 ### Requirements
 
-VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.1.0** or higher.
+VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.1.0 or higher.
+
+It also requires [PHPCSUtils](https://phpcsutils.com/) which must be installed as a PHPCS standard. If you are using composer, this will be done automattically (see below).
 
 ### With PHPCS Composer Installer
 
@@ -40,19 +42,21 @@ It should just work after that!
 
 ### Standalone
 
-1. Install PHP_CodeSniffer by following its [installation instructions](https://github.com/squizlabs/PHP_CodeSniffer#installation) (via Composer, Phar file, PEAR, or Git checkout).
+1. Install PHP_CodeSniffer (PHPCS) by following its [installation instructions](https://github.com/squizlabs/PHP_CodeSniffer#installation) (via Composer, Phar file, PEAR, or Git checkout).
 
-   Do ensure that PHP_CodeSniffer's version matches our [requirements](#requirements)
+   Do ensure that PHP_CodeSniffer's version matches our [requirements](#requirements).
 
-2. Download and uncompress the latest release:
+2. Install PHPCSUtils (required by this sniff). Download either the zip or tar.gz file from [the PHPCSUtils latest release page](https://github.com/PHPCSStandards/PHPCSUtils/releases/latest). Expand the file and rename the resulting directory to `phpcsutils`. Move the directory to a place where you'd like to keep all your PHPCS standards.
 
-Click to download either the zip or tar.gz file from [the latest release page](https://github.com/sirbrillig/phpcs-variable-analysis/releases/latest). Expand the file and rename the resulting directory to `VariableAnalysis`.
+3. Install VariableAnalysis. Download either the zip or tar.gz file from [the VariableAnalysis latest release page](https://github.com/sirbrillig/phpcs-variable-analysis/releases/latest). Expand the file and rename the resulting directory to `phpcs-variable-analysis`. Move the directory to a place where you'd like to keep all your PHPCS standards.
 
-3. Add its path to the PHP_CodeSniffer configuration:
+4. Add the paths of the newly installed standards to the [PHP_CodeSniffer installed_paths configuration](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths). The following command should append the new standards to your existing standards (be sure to supply the actual paths to the directories you created above).
 
-        phpcs --config-set installed_paths /path/to/VariableAnalysis
+        phpcs --config-set installed_paths "$(phpcs --config-show|grep installed_paths|awk '{ print $2 }'),/path/to/phpcsutils,/path/to/phpcs-variable-analysis"
 
-If you already have installed paths, [use a comma to separate them](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+    If you do not have any other standards installed, you can do this more easily (again, be sure to supply the actual paths):
+
+        phpcs --config-set installed_paths /path/to/phpcsutils,/path/to/phpcs-variable-analysis
 
 ## Customization
 
@@ -85,7 +89,6 @@ To set these these options, you must use XML in your ruleset. For details, see t
 - [ImportDetection](https://github.com/sirbrillig/phpcs-import-detection): A set of phpcs sniffs to look for unused or unimported symbols.
 - [phpcs-changed](https://github.com/sirbrillig/phpcs-changed): Run phpcs on files, but only report warnings/errors from lines which were changed.
 
-
 ## Original
 
 This was forked from the excellent work in https://github.com/illusori/PHP_Codesniffer-VariableAnalysis
@@ -107,7 +110,6 @@ To run linting, use:
 
 ```
 composer lint
-composer lint-self
 ```
 
 To run static analysis, use:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 
 VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.1.0 or higher.
 
-It also requires [PHPCSUtils](https://phpcsutils.com/) which must be installed as a PHPCS standard. If you are using composer, this will be done automattically (see below).
+It also requires [PHPCSUtils](https://phpcsutils.com/) which must be installed as a PHPCS standard. If you are using composer, this will be done automatically (see below).
 
 ### With PHPCS Composer Installer
 

--- a/VariableAnalysis/ruleset.xml
+++ b/VariableAnalysis/ruleset.xml
@@ -4,6 +4,8 @@
 
  <!-- If you want everything, with the defaults, just include this line -->
  <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis"/>
+ <!-- PHPCSUtils is required for this sniff to operate -->
+ <rule ref="PHPCSUtils"/>
  <!--
     You can also refer to these policy codes to customize them:
       VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable


### PR DESCRIPTION
As part of an effort to make sure that the dependencies are correctly installed, this adds `PHPCSUtils` as a dependency to the sniff. Without this change, it's possible to use `VariableAnalysis` functionally without phpcsutils until we hit a code path that needs it. In the interest of "fail fast" and giving a slightly more helpful error, this will fail immediately if the library is not there.

```
ERROR: Referenced sniff "PHPCSUtils" does not exist

Run "phpcs --help" for usage information
```

This also updates the README to include installation instructions for PHPCSUtils.