### PR TITLE
Composer: remove the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "phpcsstandards/phpcsutils": "^1.0"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
         "sirbrillig/phpcs-import-detection": "^1.1",
         "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",


### PR DESCRIPTION
The Dealerdirect Composer PHPCS plugin is already a (non-dev) requirement of PHPCSUtils, so will be installed whether you require it or not.

By removing it from the `composer.json` file, potential conflicts between the versions allowed by PHPCSUtils and this plugin are prevented.

Note: The plugin has released a new version last week and the new version of PHPCSUtils which was also released a few days back, already allows for it. The new version of the plugin includes support for Composer 2.0 and allows for testing standards with the plugin on PHP 8 and with PHPCS 4.x-dev.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0