### PR TITLE
Mark concatenation inside another expression as variable read

### DIFF
--- a/Tests/VariableAnalysisSniff/WhileLoopTest.php
+++ b/Tests/VariableAnalysisSniff/WhileLoopTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class WhileLoopTest extends BaseTestCase {
+  public function testFunctionWithWhileLoopWarnings() {
+    $fixtureFile = $this->getFixture('FunctionWithWhileLoopFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      38,
+      46,
+      48,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+}

--- a/Tests/VariableAnalysisSniff/WhileLoopTest.php
+++ b/Tests/VariableAnalysisSniff/WhileLoopTest.php
@@ -12,7 +12,6 @@ class WhileLoopTest extends BaseTestCase {
     $expectedWarnings = [
       38,
       46,
-      48,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
@@ -1,0 +1,49 @@
+<?php
+
+function loopAndPush($parts) {
+  $suggestions = [];
+  while ($part = array_shift($parts)) {
+    $suggestions[] = $part;
+  }
+  return $suggestions;
+}
+
+function concatAndAssignAndPush($parts) {
+  $suggestions = [];
+  $suggestion = 'block';
+  while ($part = array_shift($parts)) {
+    $suggestions[] = $suggestion .= '__' . strtr($part, '-', '_');
+  }
+  return $suggestions;
+}
+
+function concatAndAssignAndPushWithoutLoop() {
+  $suggestions = [];
+  $suggestion = 'block';
+  $suggestions[] = $suggestion .= '__';
+  return $suggestions;
+}
+
+function concatAndPush($parts) {
+  $suggestions = [];
+  $suggestion = 'block';
+  while ($part = array_shift($parts)) {
+    $suggestions[] = $suggestion . '__' . strtr($part, '-', '_');
+  }
+  return $suggestions;
+}
+
+function whileLoopAssignWithUndefinedShift() {
+  $suggestions = [];
+  while ($part = array_shift($parts)) { // undefined variable parts
+    $suggestions[] = $part;
+  }
+  return $suggestions;
+}
+
+function loopAndPushWithUndefinedArray($parts) {
+  while ($part = array_shift($parts)) {
+    $suggestions[] = $part; // undefined variable suggestions
+  }
+  return $suggestions; // undefined variable suggestions
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
@@ -47,3 +47,21 @@ function loopAndPushWithUndefinedArray($parts) {
   }
   return $suggestions; // undefined variable suggestions
 }
+
+function concatAndAssignAndPush2($parts) {
+  $suggestions = [];
+  $suggestion = 'block';
+  while ($part = array_shift($parts)) {
+    $suggestions[] = ( $suggestion .= '__' . strtr($part, '-', '_') );
+  }
+  return $suggestions;
+}
+
+function concatAndAssignAndPush3($parts) {
+  $suggestions = [];
+  $suggestion = 'block';
+  while ($part = array_shift($parts)) {
+    $suggestions[] = getPrefix() . $suggestion .= '__' . strtr($part, '-', '_');
+  }
+  return $suggestions;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
@@ -45,7 +45,7 @@ function loopAndPushWithUndefinedArray($parts) {
   while ($part = array_shift($parts)) {
     $suggestions[] = $part; // undefined variable suggestions
   }
-  return $suggestions; // undefined variable suggestions
+  return $suggestions;
 }
 
 function concatAndAssignAndPush2($parts) {

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithWhileLoopFixture.php
@@ -65,3 +65,10 @@ function concatAndAssignAndPush3($parts) {
   }
   return $suggestions;
 }
+
+function concatAndAssignAndPush4($parts) {
+  $suggestion = 'block';
+  while ($part = array_shift($parts)) {
+    addToSuggestion($suggestion .= $part);
+  }
+}

--- a/VariableAnalysis/Lib/Constants.php
+++ b/VariableAnalysis/Lib/Constants.php
@@ -8,6 +8,10 @@ class Constants {
    *  by reference, the arguments are numbered starting from 1 and an elipsis '...'
    *  means all argument numbers after the previous should be considered pass-by-reference.
    *
+   *  This does not need to cover all pass-by-reference arguments, only the
+   *  ones which can be passed an undefined variable (eg: `$matches` in
+   *  `preg_match`) and will define that variable.
+   *
    *  @return array[]
    */
   public static function getPassByReferenceFunctions() {
@@ -28,16 +32,6 @@ class Constants {
       'apcu_fetch' => [2],
       'apcu_inc' => [3],
       'areConfusable' => [3],
-      'array_multisort' => [1],
-      'array_pop' => [1],
-      'array_push' => [1],
-      'array_replace' => [1],
-      'array_replace_recursive' => [1, 2, 3, '...'],
-      'array_shift' => [1],
-      'array_splice' => [1],
-      'array_unshift' => [1],
-      'array_walk' => [1],
-      'array_walk_recursive' => [1],
       'arsort' => [1],
       'asort' => [1],
       'bindColumn' => [2],

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -173,7 +173,7 @@ class Helpers {
    * @return bool
    */
   public static function isTokenInsideFunctionUseImport(File $phpcsFile, $stackPtr) {
-    return (bool) self::getUseIndexForUseImport($phpcsFile, $stackPtr);
+    return is_int(self::getUseIndexForUseImport($phpcsFile, $stackPtr));
   }
 
   /**
@@ -313,7 +313,7 @@ class Helpers {
     $token = $tokens[$stackPtr];
 
     $arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
-    $isTokenInsideArrowFunctionBody = (bool) $arrowFunctionIndex;
+    $isTokenInsideArrowFunctionBody = is_int($arrowFunctionIndex);
     if ($isTokenInsideArrowFunctionBody) {
       // Get the list of variables defined by the arrow function
       // If this matches any of them, the scope is the arrow function,

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -97,7 +97,17 @@ class Helpers {
    * @return bool
    */
   public static function isTokenInsideFunctionDefinitionArgumentList(File $phpcsFile, $stackPtr) {
-    return (bool) self::getFunctionIndexForFunctionArgument($phpcsFile, $stackPtr);
+    return is_int(self::getFunctionIndexForFunctionArgument($phpcsFile, $stackPtr));
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return bool
+   */
+  public static function isTokenInsideFunctionCall(File $phpcsFile, $stackPtr) {
+    return is_int(self::getFunctionIndexForFunctionCallArgument($phpcsFile, $stackPtr));
   }
 
   /**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -851,4 +851,19 @@ class Helpers {
     }
     return false;
   }
+
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return bool
+   */
+  public static function isInsideSubExpression(File $phpcsFile, $stackPtr) {
+    $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
+    $previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, $previousStatementPtr, true);
+    if (is_int($previousTokenPtr)) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -858,9 +858,12 @@ class Helpers {
    *
    * @return bool
    */
-  public static function isInsideSubExpression(File $phpcsFile, $stackPtr) {
-    $previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
-    $previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, $previousStatementPtr, true);
+  public static function isTokenInsideAssignmentRHS(File $phpcsFile, $stackPtr) {
+    $previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET, T_OPEN_CURLY_BRACKET, T_COMMA], $stackPtr - 1);
+    if (! is_int($previousStatementPtr)) {
+      $previousStatementPtr = 1;
+    }
+    $previousTokenPtr = $phpcsFile->findPrevious([T_EQUAL], $stackPtr - 1, $previousStatementPtr);
     if (is_int($previousTokenPtr)) {
       return true;
     }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1399,7 +1399,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Is the next non-whitespace an assignment?
     if ($this->processVariableAsAssignment($phpcsFile, $stackPtr, $varName, $currScope)) {
-      if (Helpers::isTokenInsideAssignmentRHS($phpcsFile, $stackPtr)) {
+      if (Helpers::isTokenInsideAssignmentRHS($phpcsFile, $stackPtr) || Helpers::isTokenInsideFunctionCall($phpcsFile, $stackPtr)) {
         Helpers::debug("found assignment that's also inside an expression");
         $this->markVariableRead($varName, $stackPtr, $currScope);
         return;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1399,6 +1399,11 @@ class VariableAnalysisSniff implements Sniff {
 
     // Is the next non-whitespace an assignment?
     if ($this->processVariableAsAssignment($phpcsFile, $stackPtr, $varName, $currScope)) {
+      if (Helpers::isInsideSubExpression($phpcsFile, $stackPtr)) {
+        Helpers::debug("found assignment that's also inside an expression");
+        $this->markVariableRead($varName, $stackPtr, $currScope);
+        return;
+      }
       Helpers::debug('found assignment');
       return;
     }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1399,7 +1399,7 @@ class VariableAnalysisSniff implements Sniff {
 
     // Is the next non-whitespace an assignment?
     if ($this->processVariableAsAssignment($phpcsFile, $stackPtr, $varName, $currScope)) {
-      if (Helpers::isInsideSubExpression($phpcsFile, $stackPtr)) {
+      if (Helpers::isTokenInsideAssignmentRHS($phpcsFile, $stackPtr)) {
         Helpers::debug("found assignment that's also inside an expression");
         $this->markVariableRead($varName, $stackPtr, $currScope);
         return;


### PR DESCRIPTION
Concatenation (or other variable assignment) counts as a "write" to a variable, but not as a "read". That way code like this produces an unused variable warning:

```php
$foo = 'hi';
$foo .= ' friend';
```

However, in PHP if the assignment is _inside_ another expression, then the assignment should count as a "read" as well, as in the following code, which should produce no warning:

```
$foo = 'hi';
sayHi($foo .= ' friend');
```

This PR makes the sniff aware of two such cases: when the assignment is on the right-hand-side (RHS) of another assignment, or when the assignment is inside a function call. There may be other expressions that an assignment could be part of, but this should take care of the majority of them.

Fixes #183 