### PR TITLE
Refactor and clean up reference variables

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -992,4 +992,22 @@ class VariableAnalysisTest extends BaseTestCase {
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
+
+  public function testAssignmentByReferenceWithIgnoreUnusedMatch() {
+    $fixtureFile = $this->getFixture('AssignmentByReferenceFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'ignoreUnusedRegexp',
+      '/^varX$/'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      26,
+      34,
+      35,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
 }

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -970,8 +970,11 @@ class VariableAnalysisTest extends BaseTestCase {
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
             5,
+            6,
             8,
+            9,
             11,
+            12,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -983,7 +983,9 @@ class VariableAnalysisTest extends BaseTestCase {
     $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
     $expectedWarnings = [
       26,
-      33,
+      34,
+      35,
+      43,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
@@ -40,12 +40,12 @@ function doubleUnusedThenUsedAssignmentByReference() {
   $a = new A();
   $bee = 'hello';
 
-  $var = &$a->getProp(); // unused variable $var (because it is actually $a->prop and changes to $bee on the next line)
-  $var = &$bee;
-  return $var;
+  $varX = &$a->getProp(); // unused variable $varX (because it is actually $a->prop and changes to $bee on the next line)
+  $varX = &$bee;
+  return $varX;
 }
 
-function doubleiUsedThenUsedAssignmentByReference() {
+function doubleUsedThenUsedAssignmentByReference() {
   $a = new A();
   $bee = 'hello';
 

--- a/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
@@ -23,23 +23,34 @@ function usedAssignmentByReference() {
 function unusedAssignmentByReference() {
   $a = new A();
 
-  $var = &$a->getProp();
+  $var = &$a->getProp(); // unused variable $var
   return $a;
 }
 
 function doubleUnusedAssignmentByReference() {
   $a = new A();
+  $bee = 'hello';
 
-  $var = &$a->getProp();
-  $var = &$a->getProp();
+  $var = &$a->getProp(); // unused variable $var
+  $var = &$bee; // unused variable $var
   return $a;
 }
 
 function doubleUnusedThenUsedAssignmentByReference() {
   $a = new A();
+  $bee = 'hello';
 
-  // @todo the first one should be marked as unused.
+  $var = &$a->getProp(); // unused variable $var (because it is actually $a->prop and changes to $bee on the next line)
+  $var = &$bee;
+  return $var;
+}
+
+function doubleiUsedThenUsedAssignmentByReference() {
+  $a = new A();
+  $bee = 'hello';
+
   $var = &$a->getProp();
-  $var = &$a->getProp();
+  echo $var;
+  $var = &$bee;
   return $var;
 }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithUseReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithUseReferenceFixture.php
@@ -5,3 +5,4 @@ $ref = 0;
 $function_with_use_reference = function () use (& /*comment */ $ref) {
     $ref = 1;
 };
+echo $function_with_use_reference();

--- a/Tests/VariableAnalysisSniff/fixtures/UnusedVarWithValueChangeFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/UnusedVarWithValueChangeFixture.php
@@ -2,17 +2,21 @@
 
 // Issue #111.
 function foo() {
-    $var = 'abc';
-    $var = 'def';
+    $var = 'abc'; // unused variable $var
+    $var = 'def'; // unused variable $var
 
-    $var2  = 'def';
-    $var2 .= 'ghi';
+    $var2  = 'def'; // unused variable $var2
+    $var2 .= 'ghi'; // unused variable $var2
 
-    $var3  = 10;
-    $var3 += 20;
+    $var3  = 10; // unused variable $var3
+    $var3 += 20; // unused variable $var3
+
+    $var4 = 20;
+    $var4 += 20;
+    echo $var4;
 }
 
 // Safeguard that this change doesn't influence (not) reporting on assignments to parameters passed by reference.
 function bar(&$param) {
-	$param .= 'foo';
+  $param .= 'foo';
 }

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -56,6 +56,16 @@ class VariableInfo {
   public $firstRead;
 
   /**
+   * Stack pointers of all assignments
+   *
+   * This includes both declarations and initializations and may contain
+   * duplicates!
+   *
+   * @var int[]
+   */
+  public $allAssignments = [];
+
+  /**
    * @var bool
    */
   public $ignoreUnused = false;

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -26,16 +26,6 @@ class VariableInfo {
   public $typeHint;
 
   /**
-   * @var bool
-   */
-  public $passByReference = false;
-
-  /**
-   * @var self | null
-   */
-  public $referencedVariable;
-
-  /**
    * @var int | null
    */
   public $referencedVariableScope;

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -31,12 +31,11 @@ class VariableInfo {
   public $referencedVariableScope;
 
   /**
-   * @var bool
-   */
-  public $isReference = false;
-
-  /**
    * Stack pointer of first declaration
+   *
+   * Declaration is when a variable is created but has no value assigned.
+   *
+   * Assignment by reference is also a declaration and not an initialization.
    *
    * @var int
    */

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -870,7 +870,7 @@ class VariableAnalysisSniff implements Sniff {
       $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
       // If the variable was already declared, but was not yet read, it is
       // unused because we're about to change the binding.
-      $scopeInfo = $this->getScopeInfo($currScope);
+      $scopeInfo = $this->getOrCreateScopeInfo($currScope);
       $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
       Helpers::debug('found reference variable');
       // The referenced variable may have a different name, but we don't

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -365,7 +365,7 @@ class VariableAnalysisSniff implements Sniff {
     $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
 
     // Is the variable referencing another variable? If so, mark that variable used also.
-    if ($varInfo->referencedVariableScope && $varInfo->referencedVariableScope !== $currScope) {
+    if ($varInfo->referencedVariableScope !== null && $varInfo->referencedVariableScope !== $currScope) {
       $this->markVariableAssignment($varInfo->name, $stackPtr, $varInfo->referencedVariableScope);
     }
 
@@ -576,7 +576,7 @@ class VariableAnalysisSniff implements Sniff {
   protected function processVariableAsUseImportDefinition(File $phpcsFile, $stackPtr, $varName, $outerScope) {
     $tokens = $phpcsFile->getTokens();
 
-    Helpers::debug("processVariableAsUseImportDefinition", $stackPtr, $varName);
+    Helpers::debug("processVariableAsUseImportDefinition", $stackPtr, $varName, $outerScope);
 
     $endOfArgsPtr = $phpcsFile->findPrevious([T_CLOSE_PARENTHESIS], $stackPtr - 1, null);
     if (! is_int($endOfArgsPtr)) {
@@ -846,14 +846,13 @@ class VariableAnalysisSniff implements Sniff {
     $this->markVariableAssignment($varName, $writtenPtr, $currScope);
 
     // Are we are reference variable?
+    $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
     $tokens = $tokens = $phpcsFile->getTokens();
     $referencePtr = $phpcsFile->findNext(Tokens::$emptyTokens, $assignPtr + 1, null, true, null, true);
-    $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
     if ($referencePtr !== false && $tokens[$referencePtr]['code'] === T_BITWISE_AND) {
       $varInfo->isReference = true;
     } elseif ($varInfo->isReference) {
-      // If this is an assigment to a reference variable then that variable is
-      // used.
+      // If this is an assigment to a reference variable then that variable is used.
       $this->markVariableRead($varName, $stackPtr, $currScope);
     }
 
@@ -1524,7 +1523,7 @@ class VariableAnalysisSniff implements Sniff {
     if ($this->allowUnusedForeachVariables && $varInfo->isForeachLoopAssociativeValue) {
       return;
     }
-    if ($varInfo->referencedVariableScope && isset($varInfo->firstInitialized)) {
+    if ($varInfo->referencedVariableScope !== null && isset($varInfo->firstInitialized)) {
       // If we're pass-by-reference then it's a common pattern to
       // use the variable to return data to the caller, so any
       // assignment also counts as "variable use" for the purposes

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -870,9 +870,8 @@ class VariableAnalysisSniff implements Sniff {
       $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
       // If the variable was already declared, but was not yet read, it is
       // unused because we're about to change the binding.
-      if (is_int($varInfo->firstDeclared) && ! is_int($varInfo->firstRead)) {
-        $this->warnAboutUnusedVariable($phpcsFile, $varInfo);
-      }
+      $scopeInfo = $this->getScopeInfo($currScope);
+      $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
       Helpers::debug('found reference variable');
       // The referenced variable may have a different name, but we don't
       // actually need to mark it as used in this case because the act of this


### PR DESCRIPTION
This removes the multiple different ways used to track variable references and instead uses one.

This follows on the work done in #126/#128 and #120 and fixes some edge cases there. Notably, the sniff now treats a local assignment by reference (eg: `$foo = &$bar;`) as a declaration, not an initialization, since it doesn't really modify the value of anything, it effectively just creates an alias. That means that if the alias is unused, it should be reported as unused (which was already sort-of happening but it was a bit of a hack). 

It also means that before we make such an alias, we should check and report if the variable is unused from a previous binding or assignment because after that point, it will effectively be a new variable.

The biggest change in this PR is probably that now every instance of an unused variable counts as a warning, rather than just the first. The reason for this is that if we do not report later instances, if the first instance is ignored (eg: by `//phpcs:ignore`), the later instances wouldn't be reported at all.