### PR TITLE
Downgrade requirements from PHP 5.6 to 5.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,35 @@ jobs:
       - checkout
       - run: COMPOSER=composer.circleci.json composer install
       - run: COMPOSER=composer.circleci.json composer test
+  build_php5.4:
+    docker:
+      - image: lavoweb/php-5.4
+    steps:
+      - run:
+          name: PHP version check
+          command: php --version
+      - run:
+          name: Install system packages
+          command: apt-get update && apt-get -y install git
+      - checkout
+      - run:
+          name: Install composer
+          command: |
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
+            php composer-setup.php
+            php -r "unlink('composer-setup.php');"
+      - run:
+          name: Install dependencies
+          command: COMPOSER=composer.circleci.json php composer.phar install
+      - run:
+          name: Run tests
+          command: COMPOSER=composer.circleci.json php composer.phar test
 workflows:
   version: 2
   build_php_versions:
     jobs:
+      - build_php5.4
       - build_php5.6
       - build_php7.3
       - build_php7.4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 
 ### Requirements
 
-VariableAnalysis requires PHP 5.6 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.5.0 or higher.
+VariableAnalysis requires PHP 5.4 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.5.0 or higher.
 
 It also requires [PHPCSUtils](https://phpcsutils.com/) which must be installed as a PHPCS standard. If you are using composer, this will be done automatically (see below).
 
@@ -97,7 +97,7 @@ This was forked from the excellent work in https://github.com/illusori/PHP_Codes
 
 Please open issues or PRs on this repository.
 
-Any changes should be accompanied by tests and should pass linting and static analysis. Please use phpdoc (rather than actual types) for declaring types since this must run in PHP 5.6.
+Any changes should be accompanied by tests and should pass linting and static analysis. Please use phpdoc (rather than actual types) for declaring types since this must run in PHP 5.4.
 
 To run tests, make sure composer is installed, then run:
 

--- a/Tests/BaseTestCase.php
+++ b/Tests/BaseTestCase.php
@@ -8,15 +8,16 @@ use PHP_CodeSniffer\Config;
 
 class BaseTestCase extends TestCase {
   const STANDARD_NAME = 'VariableAnalysis';
-  const SNIFF_FILE = __DIR__ . '/../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php';
 
   public function prepareLocalFileForSniffs($fixtureFile) {
+    $sniffFile = __DIR__ . '/../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php';
+
     $config            = new Config();
     $config->cache     = false;
     $config->standards = [self::STANDARD_NAME];
     $config->ignored   = [];
 
-    $sniffFiles = [realpath(self::SNIFF_FILE)];
+    $sniffFiles = [realpath($sniffFile)];
     $ruleset    = new Ruleset($config);
     $ruleset->registerSniffs($sniffFiles, [], []);
     $ruleset->populateTokenListeners();

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -487,7 +487,8 @@ class Helpers {
   /**
    * @return void
    */
-  public static function debug(...$messages) {
+  public static function debug() {
+    $messages = func_get_args();
     if (! defined('PHP_CODESNIFFER_VERBOSITY')) {
       return;
     }

--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -42,6 +42,6 @@
         "phpcsstandards/phpcsutils": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.5 || ^7.0 || ^8.0"
     }
 }

--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -37,7 +37,7 @@
         "test": "./vendor/bin/phpunit --configuration phpunit.circleci.xml"
     },
     "require" : {
-        "php" : ">=5.6.0",
+        "php" : ">=5.4.0",
         "squizlabs/php_codesniffer": "^3.1",
         "phpcsstandards/phpcsutils": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "phpstan": "./vendor/bin/phpstan analyse"
     },
     "require" : {
-        "php" : ">=5.6.0",
+        "php" : ">=5.4.0",
         "squizlabs/php_codesniffer": "^3.5",
         "phpcsstandards/phpcsutils": "^1.0"
     },


### PR DESCRIPTION
There was never a good reason to disallow running under PHP 5.4. This downgrades the requirement and adds CI tests.