### PR TITLE
Replace UnusedVariable with UnusedParameter for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 
 - Warns if variables are used without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable`)
 - Warns if variables are set or declared but never used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable`)
+- Warns if function parameters are declared but never used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter`)
+- Warns if function parameters are declared but never used before other parameters that are used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameterBeforeUsed`)
 - Warns if `$this`, `self::$static_member`, `static::$static_member` is used outside class scope. (Sniff codes: `VariableAnalysis.CodeAnalysis.VariableAnalysis.SelfOutsideClass` or `VariableAnalysis.CodeAnalysis.VariableAnalysis.StaticOutsideClass`)
 
 ## Installation

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1684,6 +1684,15 @@ class VariableAnalysisSniff implements Sniff {
     if ($this->allowUnusedVariablesBeforeRequire && Helpers::isRequireInScopeAfter($phpcsFile, $varInfo, $scopeInfo)) {
       return;
     }
+
+    if ($varInfo->scopeType === ScopeType::PARAM && Helpers::areFollowingArgumentsUsed($varInfo, $scopeInfo)) {
+      $this->warnAboutUnusedParameterBeforeUsed($phpcsFile, $varInfo);
+      return;
+    }
+    if ($varInfo->scopeType === ScopeType::PARAM) {
+      $this->warnAboutUnusedParameterAfterUsed($phpcsFile, $varInfo);
+      return;
+    }
     $this->warnAboutUnusedVariable($phpcsFile, $varInfo);
   }
 
@@ -1700,6 +1709,48 @@ class VariableAnalysisSniff implements Sniff {
         "Unused %s %s.",
         $indexForWarning,
         'UnusedVariable',
+        [
+          VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
+          "\${$varInfo->name}",
+        ]
+      );
+    }
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param VariableInfo $varInfo
+   *
+   * @return void
+   */
+  protected function warnAboutUnusedParameterAfterUsed(File $phpcsFile, VariableInfo $varInfo) {
+    foreach (array_unique($varInfo->allAssignments) as $indexForWarning) {
+      Helpers::debug("variable {$varInfo->name} at end of scope looks unused");
+      $phpcsFile->addWarning(
+        "Unused %s %s.",
+        $indexForWarning,
+        'UnusedParameter',
+        [
+          VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
+          "\${$varInfo->name}",
+        ]
+      );
+    }
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param VariableInfo $varInfo
+   *
+   * @return void
+   */
+  protected function warnAboutUnusedParameterBeforeUsed(File $phpcsFile, VariableInfo $varInfo) {
+    foreach (array_unique($varInfo->allAssignments) as $indexForWarning) {
+      Helpers::debug("variable {$varInfo->name} at end of scope looks unused");
+      $phpcsFile->addWarning(
+        "Unused %s %s.",
+        $indexForWarning,
+        'UnusedParameterBeforeUsed',
         [
           VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
           "\${$varInfo->name}",


### PR DESCRIPTION
This (breaking!) change replaces `UnusedVariable` warnings for function arguments with `UnusedParameter` and `UnusedParameterBeforeUsed`.

The options `allowUnusedParametersBeforeUsed` and `allowUnusedFunctionParameters` continue to work as before including that `allowUnusedParametersBeforeUsed` defaults to true, meaning that `UnusedParameterBeforeUsed` will never show normally unless that option is explicitly set to false.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/175
