### PR TITLE
Fix performance issues around scope close detection

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -463,9 +463,11 @@ class Helpers {
    * @return ?int
    */
   private static function getPreviousArrowFunctionIndex(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
     $enclosingScopeIndex = self::findVariableScopeExceptArrowFunctions($phpcsFile, $stackPtr);
     for ($index = $stackPtr - 1; $index > $enclosingScopeIndex; $index--) {
-      if (FunctionDeclarations::isArrowFunction($phpcsFile, $index)) {
+      $token = $tokens[$index];
+      if ($token['content'] === 'fn' && FunctionDeclarations::isArrowFunction($phpcsFile, $index)) {
         return $index;
       }
     }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -727,7 +727,7 @@ class Helpers {
       $indexToStartSearch = $varInfo->firstInitialized;
     }
     $tokens = $phpcsFile->getTokens();
-    $indexToStopSearch = isset($tokens[$scopeInfo->owner]['scope_closer']) ? $tokens[$scopeInfo->owner]['scope_closer'] : null;
+    $indexToStopSearch = isset($tokens[$scopeInfo->scopeStartIndex]['scope_closer']) ? $tokens[$scopeInfo->scopeStartIndex]['scope_closer'] : null;
     if (! is_int($indexToStartSearch) || ! is_int($indexToStopSearch)) {
       return false;
     }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -295,11 +295,12 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
     $token = $tokens[$stackPtr];
 
-    if (self::isTokenInsideArrowFunctionBody($phpcsFile, $stackPtr)) {
+    $arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
+    $isTokenInsideArrowFunctionBody = (bool) $arrowFunctionIndex;
+    if ($isTokenInsideArrowFunctionBody) {
       // Get the list of variables defined by the arrow function
       // If this matches any of them, the scope is the arrow function,
       // otherwise, it uses the enclosing scope.
-      $arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
       if ($arrowFunctionIndex) {
         $variableNames = self::getVariablesDefinedByArrowFunction($phpcsFile, $arrowFunctionIndex);
         if (in_array($token['content'], $variableNames, true)) {
@@ -430,16 +431,6 @@ class Helpers {
     }
     $openParenPtr = $openParenIndices[0];
     return FunctionDeclarations::isArrowFunction($phpcsFile, $openParenPtr - 1);
-  }
-
-  /**
-   * @param File $phpcsFile
-   * @param int $stackPtr
-   *
-   * @return bool
-   */
-  public static function isTokenInsideArrowFunctionBody(File $phpcsFile, $stackPtr) {
-    return (bool) self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
   }
 
   /**

--- a/VariableAnalysis/Lib/ScopeInfo.php
+++ b/VariableAnalysis/Lib/ScopeInfo.php
@@ -11,7 +11,14 @@ class ScopeInfo {
    *
    * @var int
    */
-  public $owner;
+  public $scopeStartIndex;
+
+  /**
+   * The token index of the end of this scope, if important.
+   *
+   * @var int|null
+   */
+  public $scopeEndIndex;
 
   /**
    * The variables defined in this scope.
@@ -20,7 +27,8 @@ class ScopeInfo {
    */
   public $variables = [];
 
-  public function __construct($scopeStartIndex) {
-    $this->owner = $scopeStartIndex;
+  public function __construct($scopeStartIndex, $scopeEndIndex = null) {
+    $this->scopeStartIndex = $scopeStartIndex;
+    $this->scopeEndIndex = $scopeEndIndex;
   }
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -254,7 +254,6 @@ class VariableAnalysisSniff implements Sniff {
    */
   private function searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr) {
     if (! in_array($stackPtr, $this->scopeEndIndices, true)) {
-      Helpers::debug('this is not in scopeEndIndices', $stackPtr, $this->scopeEndIndices);
       return;
     }
     $scopeIndicesThisCloses = array_reduce($this->scopeStartEndPairs, function ($found, $scope) use ($stackPtr) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -29,11 +29,18 @@ class VariableAnalysisSniff implements Sniff {
   private $scopes = [];
 
   /**
-   * A list of token indices which start and end scopes and will be used to check for unused variables.
+   * A list of token index pairs which start and end scopes and will be used to check for unused variables.
    *
    * @var ScopeInfo[]
    */
   private $scopeStartEndPairs = [];
+
+  /**
+   * A list of token indices which end scopes and will be used to check for unused variables.
+   *
+   * @var int[]
+   */
+  private $scopeEndIndices = [];
 
   /**
    * A list of custom functions which pass in variables to be initialized by
@@ -202,7 +209,9 @@ class VariableAnalysisSniff implements Sniff {
       T_CLOSURE,
     ];
 
-    $this->searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr);
+    if (in_array($stackPtr, $this->scopeEndIndices, true)) {
+      $this->searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr);
+    }
 
     $token = $tokens[$stackPtr];
 
@@ -233,6 +242,7 @@ class VariableAnalysisSniff implements Sniff {
       Helpers::debug('found scope condition', $token);
       $scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $stackPtr);
       $this->scopeStartEndPairs[] = new ScopeInfo($stackPtr, $scopeEndIndex);
+      $this->scopeEndIndices[] = $scopeEndIndex;
       return;
     }
   }


### PR DESCRIPTION
This PR tackles the largest performance issues with the sniff that I was able to find:

- We were searching to see if every single token processed was a scope closer. Now we cache that data when we find it instead.
- When testing to see if every variable is inside an arrow function, we were using `FunctionDeclarations::isArrowFunction` on every token before it in the scope. Now we only check tokens that have a content of `'fn'`.

In my testing with a large file, this reduced the runtime from about 2 minutes to about 2 seconds.