### PR TITLE
Allow undefined variables inside `isset` and `empty`

### DIFF
--- a/Tests/VariableAnalysisSniff/IssetTest.php
+++ b/Tests/VariableAnalysisSniff/IssetTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class IssetTest extends BaseTestCase {
+  public function testIssetVariableUse() {
+    $fixtureFile = $this->getFixture('IssetFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      4,
+      23, // ideally this should not be a warning, but will be because it is difficult to know: https://github.com/sirbrillig/phpcs-variable-analysis/issues/202#issuecomment-688507314
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/IssetFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/IssetFixture.php
@@ -23,3 +23,15 @@ function shouldIgnoreUndefinedVariableUseAfterIsset() {
     doSomething($undefinedVar); // ideally this should not be a warning, but will be because it is difficult to know: https://github.com/sirbrillig/phpcs-variable-analysis/issues/202#issuecomment-688507314
   }
 }
+
+function shouldCountVariableUseInsideIssetAsRead($definedVar) {
+  if (isset($definedVar)) {
+    doSomething();
+  }
+}
+
+function shouldCountVariableUseInsideEmptyAsRead($definedVar) {
+  if (empty($definedVar)) {
+    doSomething();
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/IssetFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/IssetFixture.php
@@ -1,0 +1,25 @@
+<?php
+
+function normalFunctionShouldNotIgnoreUndefinedVariable() {
+  if (isActive($undefinedVar)) { // should report undefined variable $undefinedVar
+    doSomething();
+  }
+}
+
+function issetShouldIgnoreUndefinedVariable() {
+  if (isset($undefinedVar)) {
+    doSomething();
+  }
+}
+
+function emptyShouldIgnoreUndefinedVariable() {
+  if (! empty($undefinedVar)) {
+    doSomething();
+  }
+}
+
+function shouldIgnoreUndefinedVariableUseAfterIsset() {
+  if (isset($undefinedVar)) {
+    doSomething($undefinedVar); // ideally this should not be a warning, but will be because it is difficult to know: https://github.com/sirbrillig/phpcs-variable-analysis/issues/202#issuecomment-688507314
+  }
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -107,6 +107,9 @@ class Helpers {
    *
    * Will also work for the parenthesis that make up the function definition's arguments list.
    *
+   * For arguments inside a function call, rather than a definition, use
+   * `getFunctionIndexForFunctionCallArgument`.
+   *
    * @param File $phpcsFile
    * @param int $stackPtr
    *
@@ -726,6 +729,58 @@ class Helpers {
     }
     $requireTokenIndex = $phpcsFile->findNext($requireTokens, $indexToStartSearch + 1, $indexToStopSearch);
     if (is_int($requireTokenIndex)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Find the index of the function keyword for a token in a function call's arguments
+   *
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return ?int
+   */
+  public static function getFunctionIndexForFunctionCallArgument(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
+    $token = $tokens[$stackPtr];
+    if (empty($token['nested_parenthesis'])) {
+      return null;
+    }
+    $startingParenthesis = array_keys($token['nested_parenthesis']);
+    $startOfArguments = end($startingParenthesis);
+
+    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonFunctionTokenTypes[] = T_STRING;
+    $nonFunctionTokenTypes[] = T_BITWISE_AND;
+    $functionPtr = self::getIntOrNull($phpcsFile->findPrevious($nonFunctionTokenTypes, $startOfArguments - 1, null, true, null, true));
+    if (! is_int($functionPtr)) {
+      return null;
+    }
+    return $functionPtr;
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return bool
+   */
+  public static function isVariableInsideIssetOrEmpty(File $phpcsFile, $stackPtr) {
+    $functionIndex = self::getFunctionIndexForFunctionCallArgument($phpcsFile, $stackPtr);
+    if (! is_int($functionIndex)) {
+      return false;
+    }
+    $tokens = $phpcsFile->getTokens();
+    if (! isset($tokens[$functionIndex])) {
+      return false;
+    }
+    $allowedFunctionNames = [
+      'isset',
+      'empty',
+    ];
+    if (in_array($tokens[$functionIndex]['content'], $allowedFunctionNames, true)) {
       return true;
     }
     return false;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -133,6 +133,10 @@ class Helpers {
       $startOfArguments = end($startingParenthesis);
     }
 
+    if (! is_int($startOfArguments)) {
+      return null;
+    }
+
     $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
     $nonFunctionTokenTypes[] = T_STRING;
     $nonFunctionTokenTypes[] = T_BITWISE_AND;
@@ -750,6 +754,9 @@ class Helpers {
     }
     $startingParenthesis = array_keys($token['nested_parenthesis']);
     $startOfArguments = end($startingParenthesis);
+    if (! is_int($startOfArguments)) {
+      return null;
+    }
 
     $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
     $nonFunctionTokenTypes[] = T_STRING;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -759,10 +759,11 @@ class Helpers {
     }
 
     $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
-    $nonFunctionTokenTypes[] = T_STRING;
-    $nonFunctionTokenTypes[] = T_BITWISE_AND;
     $functionPtr = self::getIntOrNull($phpcsFile->findPrevious($nonFunctionTokenTypes, $startOfArguments - 1, null, true, null, true));
-    if (! is_int($functionPtr)) {
+    if (! is_int($functionPtr) || ! isset($tokens[$functionPtr]['code'])) {
+      return null;
+    }
+    if ($tokens[$functionPtr]['code'] === 'function' || ($tokens[$functionPtr]['content'] === 'fn' && FunctionDeclarations::isArrowFunction($phpcsFile, $functionPtr))) {
       return null;
     }
     return $functionPtr;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1363,12 +1363,6 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
 
-    // Are we an isset or empty call?
-    if (Helpers::isVariableInsideIssetOrEmpty($phpcsFile, $stackPtr)) {
-      Helpers::debug('found isset or empty');
-      return;
-    }
-
     // Are we a $GLOBALS, $_REQUEST, etc superglobal?
     if ($this->processVariableAsSuperGlobal($varName)) {
       Helpers::debug('found superglobal');
@@ -1443,6 +1437,13 @@ class VariableAnalysisSniff implements Sniff {
     if (Helpers::isVariableInsideElseCondition($phpcsFile, $stackPtr) || Helpers::isVariableInsideElseBody($phpcsFile, $stackPtr)) {
       Helpers::debug('found variable inside else condition or body');
       $this->processVaribleInsideElse($phpcsFile, $stackPtr, $varName, $currScope);
+      return;
+    }
+
+    // Are we an isset or empty call?
+    if (Helpers::isVariableInsideIssetOrEmpty($phpcsFile, $stackPtr)) {
+      Helpers::debug('found isset or empty');
+      $this->markVariableRead($varName, $stackPtr, $currScope);
       return;
     }
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1363,6 +1363,12 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
 
+    // Are we an isset or empty call?
+    if (Helpers::isVariableInsideIssetOrEmpty($phpcsFile, $stackPtr)) {
+      Helpers::debug('found isset or empty');
+      return;
+    }
+
     // Are we a $GLOBALS, $_REQUEST, etc superglobal?
     if ($this->processVariableAsSuperGlobal($varName)) {
       Helpers::debug('found superglobal');


### PR DESCRIPTION
PHP allows undefined variables to be used inside `isset()` and `empty()`. This change prevents such usages from generating warnings.

Note that this only affects the usage of variables inside the call sites of those functions, it does not mean that a variable who's existence is confirmed with `isset()` will not be marked as undefined in later reads. That's definitely not ideal, but detecting those use-cases is very difficult, as described in [this comment](https://github.com/sirbrillig/phpcs-variable-analysis/issues/202#issuecomment-688507314).

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/202