### PR TITLE
Add sniff codes for array assignment shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 Please note that this README is for VariableAnalysis v3. For documentation about v2, [see this page](https://github.com/sirbrillig/phpcs-variable-analysis/blob/2.8.2/README.md).
 
 - Warns if variables are used without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable`)
+- Warns if variables are used for an array push shortcut without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedArrayVariable`)
 - Warns if variables are set or declared but never used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable`)
 - Warns if function parameters are declared but never used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter`)
 - Warns if function parameters are declared but never used before other parameters that are used. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameterBeforeUsed`)

--- a/Tests/VariableAnalysisSniff/ArrayAssignmentShortcutTest.php
+++ b/Tests/VariableAnalysisSniff/ArrayAssignmentShortcutTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class ArrayAssignmentShortcutTest extends BaseTestCase {
+  public function testArrayAssignmentReportsCorrectLines() {
+    $fixtureFile = $this->getFixture('ArrayAssignmentShortcutFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      21,
+      27,
+      28,
+      29,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testArrayAssignmentHasCorrectSniffCodes() {
+    $fixtureFile = $this->getFixture('ArrayAssignmentShortcutFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+
+    $warnings = $phpcsFile->getWarnings();
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedArrayVariable', $warnings[21][5][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedArrayVariable', $warnings[27][5][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[28][5][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[29][10][0]['source']);
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrayAssignmentShortcutFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrayAssignmentShortcutFixture.php
@@ -1,0 +1,30 @@
+<?php
+
+function arrayAssignmentWithDefine() {
+    $ar1 = [];
+    $ar1[]= 'hello';
+    echo $ar1;
+}
+
+function arrayAssignmentWithDefineWithoutRead() {
+    $ar1 = [];
+    $ar1[]= 'hello';
+}
+
+function arrayAssignmentWithDefineWithSpace() {
+    $ar1 = [];
+    $ar1 []= 'hello';
+    echo $ar1;
+}
+
+function arrayAssignmentWithoutDefine() {
+    $ar1[]= 'hello'; // should warn about undefined variable
+    echo $ar1;
+    $ar1[] = 'goodbye';
+}
+
+function arrayAssignmentWithoutDefineOrRead() {
+    $ar1[]= 'hello'; // should warn about unused variable and undefined variable
+    $foo = 'bar'; // should warn about unused variable
+    echo $bar; // should warn about undefined variable
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -793,4 +793,41 @@ class Helpers {
     }
     return false;
   }
+
+  /**
+   * @param File $phpcsFile
+   * @param int $stackPtr
+   *
+   * @return bool
+   */
+  public static function isVariableArrayPushShortcut(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
+    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+
+    $arrayPushOperatorIndex1 = self::getIntOrNull($phpcsFile->findNext($nonFunctionTokenTypes, $stackPtr + 1, null, true, null, true));
+    if (! is_int($arrayPushOperatorIndex1)) {
+      return false;
+    }
+    if (! isset($tokens[$arrayPushOperatorIndex1]['content']) || $tokens[$arrayPushOperatorIndex1]['content'] !== '[') {
+      return false;
+    }
+
+    $arrayPushOperatorIndex2 = self::getIntOrNull($phpcsFile->findNext($nonFunctionTokenTypes, $arrayPushOperatorIndex1 + 1, null, true, null, true));
+    if (! is_int($arrayPushOperatorIndex2)) {
+      return false;
+    }
+    if (! isset($tokens[$arrayPushOperatorIndex2]['content']) || $tokens[$arrayPushOperatorIndex2]['content'] !== ']') {
+      return false;
+    }
+
+    $arrayPushOperatorIndex3 = self::getIntOrNull($phpcsFile->findNext($nonFunctionTokenTypes, $arrayPushOperatorIndex2 + 1, null, true, null, true));
+    if (! is_int($arrayPushOperatorIndex3)) {
+      return false;
+    }
+    if (! isset($tokens[$arrayPushOperatorIndex3]['content']) || $tokens[$arrayPushOperatorIndex3]['content'] !== '=') {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -560,6 +560,10 @@ class VariableAnalysisSniff implements Sniff {
     $this->markVariableRead($varName, $stackPtr, $currScope);
     if ($this->isVariableUndefined($varName, $stackPtr, $currScope) === true) {
       Helpers::debug("variable $varName looks undefined");
+      if (Helpers::isVariableArrayPushShortcut($phpcsFile, $stackPtr)) {
+        $this->warnAboutUndefinedArrayPushShortcut($phpcsFile, $varName, $stackPtr);
+        return;
+      }
       $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
     }
   }
@@ -1761,6 +1765,21 @@ class VariableAnalysisSniff implements Sniff {
         "Variable %s is undefined.",
         $stackPtr,
         'UndefinedVariable',
+        ["\${$varName}"]
+      );
+  }
+  /**
+   * @param File $phpcsFile
+   * @param string $varName
+   * @param int $stackPtr
+   *
+   * @return void
+   */
+  protected function warnAboutUndefinedArrayPushShortcut(File $phpcsFile, $varName, $stackPtr) {
+      $phpcsFile->addWarning(
+        "Array variable %s is undefined.",
+        $stackPtr,
+        'UndefinedArrayVariable',
         ["\${$varName}"]
       );
   }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -560,12 +560,7 @@ class VariableAnalysisSniff implements Sniff {
     $this->markVariableRead($varName, $stackPtr, $currScope);
     if ($this->isVariableUndefined($varName, $stackPtr, $currScope) === true) {
       Helpers::debug("variable $varName looks undefined");
-      $phpcsFile->addWarning(
-        "Variable %s is undefined.",
-        $stackPtr,
-        'UndefinedVariable',
-        ["\${$varName}"]
-      );
+      $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
     }
   }
 
@@ -654,7 +649,7 @@ class VariableAnalysisSniff implements Sniff {
     // If it's undefined in the enclosing scope, the use is wrong
     if ($this->isVariableUndefined($varName, $stackPtr, $outerScope) === true) {
       Helpers::debug("variable '{$varName}' in function definition looks undefined in scope", $outerScope);
-      $phpcsFile->addWarning("Variable %s is undefined.", $stackPtr, 'UndefinedVariable', ["\${$varName}"]);
+      $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
       return;
     }
 
@@ -1494,12 +1489,7 @@ class VariableAnalysisSniff implements Sniff {
 
     if (count($assignmentsInsideAttachedBlocks) === count($allAssignmentIndices)) {
       Helpers::debug("variable $varName inside else looks undefined");
-      $phpcsFile->addWarning(
-        "Variable %s is undefined.",
-        $stackPtr,
-        'UndefinedVariable',
-        ["\${$varName}"]
-      );
+      $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
       return;
     }
 
@@ -1757,5 +1747,21 @@ class VariableAnalysisSniff implements Sniff {
         ]
       );
     }
+  }
+
+  /**
+   * @param File $phpcsFile
+   * @param string $varName
+   * @param int $stackPtr
+   *
+   * @return void
+   */
+  protected function warnAboutUndefinedVariable(File $phpcsFile, $varName, $stackPtr) {
+      $phpcsFile->addWarning(
+        "Variable %s is undefined.",
+        $stackPtr,
+        'UndefinedVariable',
+        ["\${$varName}"]
+      );
   }
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -562,6 +562,8 @@ class VariableAnalysisSniff implements Sniff {
       Helpers::debug("variable $varName looks undefined");
       if (Helpers::isVariableArrayPushShortcut($phpcsFile, $stackPtr)) {
         $this->warnAboutUndefinedArrayPushShortcut($phpcsFile, $varName, $stackPtr);
+        // Mark the variable as defined if it's of the form `$x[] = 1;`
+        $this->markVariableAssignment($varName, $stackPtr, $currScope);
         return;
       }
       $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);


### PR DESCRIPTION
This replaces the `UndefinedVariable` sniff code with `UndefinedArrayVariable` if the variable is an "array push shortcut" (I don't know of a better name for it): `$x[] = 5;`

Also, when marking such a variable, this sniff considers that variable defined at that point going forward. (This will prevent future uses of the same variable from being reported as undefined.)

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/98