### PR TITLE
Add missing superglobals

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
@@ -57,3 +57,17 @@ function globalWithUnusedFunctionArg($user_type, $text, $testvar) { // should wa
 }
 
 echo $sunday;
+
+function function_with_reserved_variables() {
+  $opts = [];
+  $url  = 'https://example.com/';
+  $context = stream_context_create($opts);
+  $response = @file_get_contents($url, false, $context);
+  $response_headers = handle_response_headers($http_response_header);
+  return [
+    $response,
+    $response_headers,
+    $php_errormsg,
+    $HTTP_RAW_POST_DATA,
+  ];
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -799,6 +799,9 @@ class VariableAnalysisSniff implements Sniff {
       '_ENV',
       'argv',
       'argc',
+      'php_errormsg',
+      'http_response_header',
+      'HTTP_RAW_POST_DATA',
     ])) {
       return true;
     }


### PR DESCRIPTION
This adds support for [some superglobals](https://www.php.net/manual/en/reserved.variables.php) which were previously missing: 

- `$http_response_header`
- `$HTTP_RAW_POST_DATA`
- `$php_errormsg`

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/176