### PR TITLE
Add tests for if/loop condition undefined array

### DIFF
--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -30,6 +30,8 @@ class IfConditionTest extends BaseTestCase {
       101,
       159,
       161,
+      166,
+      168,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -58,6 +60,10 @@ class IfConditionTest extends BaseTestCase {
       77,
       86,
       88,
+      130,
+      131,
+      136,
+      137,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -29,9 +29,7 @@ class IfConditionTest extends BaseTestCase {
       98,
       101,
       159,
-      161,
       166,
-      168,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -61,9 +59,7 @@ class IfConditionTest extends BaseTestCase {
       86,
       88,
       130,
-      131,
       136,
-      137,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -28,6 +28,8 @@ class IfConditionTest extends BaseTestCase {
       87,
       98,
       101,
+      159,
+      161,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
@@ -160,3 +160,10 @@ function ifConditionWithUndefinedArrayAssignment($first) {
   }
   return $things; // undefined variable
 }
+
+function loopAndPushWithUndefinedArray($parts) {
+  while ($part = array_shift($parts)) {
+    $suggestions[] = $part; // undefined array variable
+  }
+  return $suggestions; // undefined variable
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
@@ -158,12 +158,12 @@ function ifConditionWithUndefinedArrayAssignment($first) {
   if ($first) {
     $things[] = 'person'; // undefined array variable
   }
-  return $things; // undefined variable
+  return $things;
 }
 
 function loopAndPushWithUndefinedArray($parts) {
   while ($part = array_shift($parts)) {
     $suggestions[] = $part; // undefined array variable
   }
-  return $suggestions; // undefined variable
+  return $suggestions;
 }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
@@ -145,3 +145,18 @@ function ifConditionWithPossibleUse($first) {
     echo $name;
   }
 }
+
+function ifConditionWithArrayAssignment($first) {
+  $things = [];
+  if ($first) {
+    $things[] = 'person';
+  }
+  return $things;
+}
+
+function ifConditionWithUndefinedArrayAssignment($first) {
+  if ($first) {
+    $things[] = 'person'; // undefined array variable
+  }
+  return $things; // undefined variable
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
@@ -128,11 +128,11 @@ function ifConditionWithPossibleUse($first) {
 function ifConditionWithUndefinedArrayAssignment($first) {
   if ($first)
     $things[] = 'person'; // undefined array variable
-  return $things; // undefined variable
+  return $things;
 }
 
 function loopAndPushWithUndefinedArray($parts) {
   while ($part = array_shift($parts))
     $suggestions[] = $part; // undefined array variable
-  return $suggestions; // undefined variable
+  return $suggestions;
 }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
@@ -124,3 +124,15 @@ function ifConditionWithPossibleUse($first) {
   if ($first)
     echo $name;
 }
+
+function ifConditionWithUndefinedArrayAssignment($first) {
+  if ($first)
+    $things[] = 'person'; // undefined array variable
+  return $things; // undefined variable
+}
+
+function loopAndPushWithUndefinedArray($parts) {
+  while ($part = array_shift($parts))
+    $suggestions[] = $part; // undefined array variable
+  return $suggestions; // undefined variable
+}


### PR DESCRIPTION
#205 made it so that future uses of a variable after an array push are marked as defined. However, that is incorrect in the case of the array assignment being within the body of an `if` statement, an `else` statement, or a `while`, `do`, or `for` loop.

This modifies the code such that those cases are correctly reported as undefined variables.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/210