### PR TITLE
Backport all of 3.0 to 2.x without phpcsutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problematic variable use.
 
-**Please note that this README is for VariableAnalysis v3. For documentation about v2, [see this page](https://github.com/sirbrillig/phpcs-variable-analysis/blob/2.x-legacy/README.md).**
-
 - Warns if variables are used without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable`)
 - Warns if variables are used for an array push shortcut without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedArrayVariable`)
 - Warns if variables are used inside `unset()` without being defined. (Sniff code: `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedUnsetVariable`)
@@ -19,8 +17,6 @@ Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problemati
 ### Requirements
 
 VariableAnalysis requires PHP 5.4 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.5.0 or higher.
-
-It also requires [PHPCSUtils](https://phpcsutils.com/) which must be installed as a PHPCS standard. If you are using composer, this will be done automatically (see below).
 
 ### With PHPCS Composer Installer
 
@@ -52,17 +48,15 @@ It should just work after that!
 
    Do ensure that PHP_CodeSniffer's version matches our [requirements](#requirements).
 
-2. Install PHPCSUtils (required by this sniff). Download either the zip or tar.gz file from [the PHPCSUtils latest release page](https://github.com/PHPCSStandards/PHPCSUtils/releases/latest). Expand the file and rename the resulting directory to `phpcsutils`. Move the directory to a place where you'd like to keep all your PHPCS standards.
+2. Install VariableAnalysis. Download either the zip or tar.gz file from [the VariableAnalysis latest release page](https://github.com/sirbrillig/phpcs-variable-analysis/releases/latest). Expand the file and rename the resulting directory to `phpcs-variable-analysis`. Move the directory to a place where you'd like to keep all your PHPCS standards.
 
-3. Install VariableAnalysis. Download either the zip or tar.gz file from [the VariableAnalysis latest release page](https://github.com/sirbrillig/phpcs-variable-analysis/releases/latest). Expand the file and rename the resulting directory to `phpcs-variable-analysis`. Move the directory to a place where you'd like to keep all your PHPCS standards.
+3. Add the paths of the newly installed standards to the [PHP_CodeSniffer installed_paths configuration](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths). The following command should append the new standards to your existing standards (be sure to supply the actual paths to the directories you created above).
 
-4. Add the paths of the newly installed standards to the [PHP_CodeSniffer installed_paths configuration](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths). The following command should append the new standards to your existing standards (be sure to supply the actual paths to the directories you created above).
-
-        phpcs --config-set installed_paths "$(phpcs --config-show|grep installed_paths|awk '{ print $2 }'),/path/to/phpcsutils,/path/to/phpcs-variable-analysis"
+        phpcs --config-set installed_paths "$(phpcs --config-show|grep installed_paths|awk '{ print $2 }'),/path/to/phpcs-variable-analysis"
 
     If you do not have any other standards installed, you can do this more easily (again, be sure to supply the actual paths):
 
-        phpcs --config-set installed_paths /path/to/phpcsutils,/path/to/phpcs-variable-analysis
+        phpcs --config-set installed_paths /path/to/phpcs-variable-analysis
 
 ## Customization
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -7,7 +7,6 @@ use VariableAnalysis\Lib\ScopeInfo;
 use VariableAnalysis\Lib\ScopeType;
 use VariableAnalysis\Lib\VariableInfo;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\FunctionDeclarations;
 
 class Helpers {
   /**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -578,7 +578,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $listOpenerIndex
    *
-   * @return ?int[]
+   * @return ?array
    */
   public static function getListAssignments(File $phpcsFile, $listOpenerIndex) {
     $tokens = $phpcsFile->getTokens();

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -987,13 +987,12 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     // OK, we're a [ ... ] construct... are we being assigned to?
-    try {
-      $assignments = Lists::getAssignments($phpcsFile, $openPtr);
-    } catch (\Exception $error) {
+    $assignments = Helpers::getListAssignments($phpcsFile, $openPtr);
+    if (! $assignments) {
       return false;
     }
-    $matchingAssignment = array_reduce($assignments, function ($thisAssignment, array $assignment) use ($stackPtr) {
-      if (isset($assignment['assignment_token']) && $assignment['assignment_token'] === $stackPtr) {
+    $matchingAssignment = array_reduce($assignments, function ($thisAssignment, $assignment) use ($stackPtr) {
+      if ($assignment === $stackPtr) {
         return $assignment;
       }
       return $thisAssignment;
@@ -1030,13 +1029,12 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     // OK, we're a list (...) construct... are we being assigned to?
-    try {
-      $assignments = Lists::getAssignments($phpcsFile, $prevPtr);
-    } catch (\Exception $error) {
+    $assignments = Helpers::getListAssignments($phpcsFile, $prevPtr);
+    if (! $assignments) {
       return false;
     }
-    $matchingAssignment = array_reduce($assignments, function ($thisAssignment, array $assignment) use ($stackPtr) {
-      if (isset($assignment['assignment_token']) && $assignment['assignment_token'] === $stackPtr) {
+    $matchingAssignment = array_reduce($assignments, function ($thisAssignment, $assignment) use ($stackPtr) {
+      if ($assignment === $stackPtr) {
         return $assignment;
       }
       return $thisAssignment;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -10,8 +10,6 @@ use VariableAnalysis\Lib\Helpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\Lists;
-use PHPCSUtils\Utils\FunctionDeclarations;
 
 class VariableAnalysisSniff implements Sniff {
   /**

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -239,7 +239,7 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
     if (in_array($token['code'], $scopeStartTokenTypes, true)
-      || FunctionDeclarations::isArrowFunction($phpcsFile, $stackPtr)
+      || Helpers::isArrowFunction($phpcsFile, $stackPtr)
     ) {
       Helpers::debug('found scope condition', $token);
       $this->recordScopeStartAndEnd($phpcsFile, $stackPtr);

--- a/VariableAnalysis/ruleset.xml
+++ b/VariableAnalysis/ruleset.xml
@@ -2,6 +2,4 @@
 <ruleset name="VariableAnalysis">
   <description>Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problematic variable use.</description>
    <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis"/>
-   <!-- PHPCSUtils is required for this sniff to operate -->
-   <rule ref="PHPCSUtils"/>
 </ruleset>

--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -38,8 +38,7 @@
     },
     "require" : {
         "php" : ">=5.4.0",
-        "squizlabs/php_codesniffer": "^3.1",
-        "phpcsstandards/phpcsutils": "^1.0"
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.5 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
         "sirbrillig/phpcs-import-detection": "^1.1",
         "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
-        "phpstan/phpstan": "^0.11.8"
+        "phpstan/phpstan": "^0.11.8",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     },
     "require" : {
         "php" : ">=5.4.0",
-        "squizlabs/php_codesniffer": "^3.5",
-        "phpcsstandards/phpcsutils": "^1.0"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",


### PR DESCRIPTION
Although PHPCSUtils presents an amazing mechanism for this package to improve its compatibility and reduce false positives, as a project it remains in an alpha state and in the meantime it blocks this package from all the features added since the 2.x branch. Notably, PHP 7.4 support and improved scope detection.

This PR backports the entirety of the 3.0 branch to 2.x with the PHPCSUtils imports replaced with custom local versions that, while certainly less effective and complete than the PHPCSUtils versions, at least make the tests pass.

This would allow us to release version 2.10.0 with a lot of improvements and keep 3.0 waiting on the PHPCSUtils release cycle (which itself is waiting on PHPCS).