### PR TITLE
Treat writing to a by-reference foreach loop variable as a read

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -286,6 +286,7 @@ class VariableAnalysisTest extends BaseTestCase {
       59,
       60,
       64,
+      81,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -312,6 +313,7 @@ class VariableAnalysisTest extends BaseTestCase {
       40,
       46,
       64,
+      81,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -339,6 +341,7 @@ class VariableAnalysisTest extends BaseTestCase {
       46,
       59,
       60,
+      81,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
@@ -73,3 +73,10 @@ function function_with_array_walk($userNameParts) {
     $value = ucfirst($value);
   });
 }
+
+function function_with_foreach_with_reference($derivatives, $base_plugin_definition) {
+  foreach ($derivatives as &$entry) {
+    $entry .= $base_plugin_definition;
+  }
+  return $derivatives;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
@@ -78,5 +78,8 @@ function function_with_foreach_with_reference($derivatives, $base_plugin_definit
   foreach ($derivatives as &$entry) {
     $entry .= $base_plugin_definition;
   }
+  foreach ($derivatives as &$unused) { // unused variable
+    $base_plugin_definition .= '1';
+  }
   return $derivatives;
 }

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -31,6 +31,13 @@ class VariableInfo {
   public $referencedVariableScope;
 
   /**
+   * True if the variable is a reference but one created at runtime
+   *
+   * @var bool
+   */
+  public $isDynamicReference = false;
+
+  /**
    * Stack pointer of first declaration
    *
    * Declaration is when a variable is created but has no value assigned.

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -418,6 +418,7 @@ class VariableAnalysisSniff implements Sniff {
       return;
     }
     $varInfo->firstInitialized = $stackPtr;
+    Helpers::debug('markVariableAssignment: marked as initialized', $varName);
   }
 
   /**
@@ -1162,6 +1163,13 @@ class VariableAnalysisSniff implements Sniff {
     // Is this the value of a key => value foreach?
     if ($phpcsFile->findPrevious(T_DOUBLE_ARROW, $stackPtr - 1, $openParenPtr) !== false) {
       $varInfo->isForeachLoopAssociativeValue = true;
+    }
+
+    // Are we pass-by-reference?
+    $referencePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true, null, true);
+    if (($referencePtr !== false) && ($tokens[$referencePtr]['code'] === T_BITWISE_AND)) {
+      Helpers::debug("processVariableAsForeachLoopVar: found foreach loop variable assigned by reference");
+      $varInfo->isDynamicReference = true;
     }
 
     return true;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -945,6 +945,14 @@ class VariableAnalysisSniff implements Sniff {
 
     Helpers::debug('processVariableAsAssignment: marking as assignment in scope', $currScope);
     $this->markVariableAssignment($varName, $stackPtr, $currScope);
+
+    // If the left-hand-side of the assignment (the variable we are examining)
+    // is itself a reference, then that counts as a read as well as a write.
+    $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
+    if ($varInfo->isDynamicReference) {
+      Helpers::debug('processVariableAsAssignment: also marking as a use because variable is a reference');
+      $this->markVariableRead($varName, $stackPtr, $currScope);
+    }
   }
 
   /**


### PR DESCRIPTION
When a foreach loop variable (eg: `$foo` in `foreach($data as $foo)`) is a reference (eg: `foreach($data as &$foo)`), then any write to that variable should also count as a read, since it has the side-effect of modifying the original data (eg: `$data` in `foreach($data as &$foo)`).

Fixes part of https://github.com/sirbrillig/phpcs-variable-analysis/issues/219