### PR TITLE
Properly detect variables used in quotes inside arrow functions

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -71,3 +71,9 @@ function arrowFunctionAsExpressionWithUnusedVariableOutsideArrow($subject) { //u
     echo $post; // undefined variable $post;
 }
 
+function arrowFunctionWithVariableUsedInsideQuotes($allowed_extensions) {
+    $data = array_map( fn($extension) => '.' . $extension, $allowed_extensions );
+    $data = array_map( fn($extension) => ".$extension", $allowed_extensions );
+    $data = array_map( fn($extension) => ".{$extension}", $allowed_extensions );
+    return $data;
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -304,12 +304,14 @@ class Helpers {
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
+   * @param string $varName (optional) if it differs from the normalized 'content' of the token at $stackPtr
    *
    * @return ?int
    */
-  public static function findVariableScope(File $phpcsFile, $stackPtr) {
+  public static function findVariableScope(File $phpcsFile, $stackPtr, $varName = null) {
     $tokens = $phpcsFile->getTokens();
     $token = $tokens[$stackPtr];
+    $varName = $varName ?? self::normalizeVarName($token['content']);
 
     $arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
     $isTokenInsideArrowFunctionBody = is_int($arrowFunctionIndex);
@@ -319,7 +321,8 @@ class Helpers {
       // otherwise, it uses the enclosing scope.
       if ($arrowFunctionIndex) {
         $variableNames = self::getVariablesDefinedByArrowFunction($phpcsFile, $arrowFunctionIndex);
-        if (in_array($token['content'], $variableNames, true)) {
+        self::debug('findVariableScope: looking for', $varName, 'in arrow function variables', $variableNames);
+        if (in_array($varName, $variableNames, true)) {
           return $arrowFunctionIndex;
         }
       }
@@ -654,9 +657,10 @@ class Helpers {
     for ($index = $arrowFunctionToken['parenthesis_opener']; $index < $arrowFunctionToken['parenthesis_closer']; $index++) {
       $token = $tokens[$index];
       if ($token['code'] === T_VARIABLE) {
-        $variableNames[] = $token['content'];
+        $variableNames[] = self::normalizeVarName($token['content']);
       }
     }
+    self::debug('found these variables in arrow function token', $variableNames);
     return $variableNames;
   }
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -311,7 +311,7 @@ class Helpers {
   public static function findVariableScope(File $phpcsFile, $stackPtr, $varName = null) {
     $tokens = $phpcsFile->getTokens();
     $token = $tokens[$stackPtr];
-    $varName = $varName ?? self::normalizeVarName($token['content']);
+    $varName = isset($varName) ? $varName : self::normalizeVarName($token['content']);
 
     $arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr);
     $isTokenInsideArrowFunctionBody = is_int($arrowFunctionIndex);

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1528,12 +1528,9 @@ class VariableAnalysisSniff implements Sniff {
     }
     Helpers::debug("examining token for variable in string", $token);
 
-    $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-    if ($currScope === null) {
-      return;
-    }
     foreach ($matches[1] as $varName) {
       $varName = Helpers::normalizeVarName($varName);
+
       // Are we $this within a class?
       if ($this->processVariableAsThisWithinClass($phpcsFile, $stackPtr, $varName)) {
         continue;
@@ -1545,6 +1542,11 @@ class VariableAnalysisSniff implements Sniff {
 
       // Are we a numeric variable used for constructs like preg_replace?
       if (Helpers::isVariableANumericVariable($varName)) {
+        continue;
+      }
+
+      $currScope = Helpers::findVariableScope($phpcsFile, $stackPtr, $varName);
+      if ($currScope === null) {
         continue;
       }
 


### PR DESCRIPTION
Because of the more complex scoping rules used for arrow functions, when we look to see if a variable is used within one, we need to know the name of that variable. Previously this was done by reading the `'content'` of the token where the variable is found. However, this will not work if the variable is inside a quoted string because the token's content probably contains a lot of other string bits.

In this PR, we instead explicitly provide the detection function with the normalized variable name as we've extracted it from the string.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/220