### PR TITLE
Start inline block scope at end of condition rather than at keyword

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
@@ -136,3 +136,10 @@ function loopAndPushWithUndefinedArray($parts) {
     $suggestions[] = $part; // undefined array variable
   return $suggestions;
 }
+
+function ifElseConditionWithInlineAssignAndUseInsideElse() {
+  if($q = getData())
+    echo $q;
+  else
+    echo $q;
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1487,19 +1487,21 @@ class VariableAnalysisSniff implements Sniff {
     foreach ($allAssignmentIndices as $index) {
       foreach ($blockIndices as $blockIndex) {
         $blockToken = $tokens[$blockIndex];
-        Helpers::debug('looking at assignment', $index, 'at block index', $blockIndex, 'which is token', $blockToken);
+        Helpers::debug('for variable inside else, looking at assignment', $index, 'at block index', $blockIndex, 'which is token', $blockToken);
         if (isset($blockToken['scope_opener']) && isset($blockToken['scope_closer'])) {
           $scopeOpener = $blockToken['scope_opener'];
           $scopeCloser = $blockToken['scope_closer'];
         } else {
-          // If the `if` statement has no scope, it is probably inline, which means its scope is up until the next semicolon
-          $scopeOpener = $blockIndex + 1;
+          // If the `if` statement has no scope, it is probably inline, which
+          // means its scope is from the end of the condition up until the next
+          // semicolon
+          $scopeOpener = isset($blockToken['parenthesis_closer']) ? $blockToken['parenthesis_closer'] : $blockIndex + 1;
           $scopeCloser = $phpcsFile->findNext([T_SEMICOLON], $scopeOpener);
           if (! $scopeCloser) {
             throw new \Exception("Cannot find scope for if condition block at index {$stackPtr} while examining variable {$varName}");
           }
         }
-        Helpers::debug('looking at scope', $index, 'between', $scopeOpener, 'and', $scopeCloser);
+        Helpers::debug('for variable inside else, looking at scope', $index, 'between', $scopeOpener, 'and', $scopeCloser);
         if (Helpers::isIndexInsideScope($index, $scopeOpener, $scopeCloser)) {
           $assignmentsInsideAttachedBlocks[] = $index;
         }


### PR DESCRIPTION
When trying to determine if a variable used within an `else` block has been defined, we need to determine the scope of the associated `if` block. This is because if the definition was within that block, then the usage inside the `else` is out of scope. Here's an example:

```php
if (something()) {
  $x = 'hello';
} else {
  echo $x; // $x is undefined here
}
```

When the `if` block is using curly braces, identifying the start and end of the block is easy. However, it's a little more difficult when the block is inline:

```php
if (something())
  $x = 'hello';
else
  echo $x; // $x is undefined
```

In the inline case, we have to search for the start and end of the block. Prior to this PR, the block was considered to go from the `if` statement to the first semicolon. This works for the above case, but it doesn't work if the variable is being defined _within_ the condition:

```php
if ($x = getData())
  whatever();
else
  echo $x; // $x is defined, even though falsy
```

In this PR we modify that logic so that the block is instead considered to go from _the end of the condition_ to the first semicolon.

Reported by @djibarian in https://github.com/sirbrillig/phpcs-variable-analysis/issues/228