### PR TITLE
Allow parsing mixed HTML and PHP

### DIFF
--- a/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
+++ b/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
@@ -16,9 +16,16 @@ class ClosingPhpTagsTest extends BaseTestCase {
       16,
     ];
     $this->assertEquals($expectedWarnings, $lines);
+  }
 
-    // $warnings = $phpcsFile->getWarnings();
-    // $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[2][49][0]['source']);
-    // $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[2][49][0]['source']);
+  public function testVariableWarningsHaveCorrectSniffCodesWhenClosingTagsAreUsed() {
+    $fixtureFile = $this->getFixture('ClosingPhpTagsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+    $warnings = $phpcsFile->getWarnings();
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[6][1][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[8][6][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[13][1][0]['source']);
+    $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[16][6][0]['source']);
   }
 }

--- a/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
+++ b/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class ClosingPhpTagsTest extends BaseTestCase {
+  public function testVariableWarningsWhenClosingTagsAreUsed() {
+    $fixtureFile = $this->getFixture('ClosingPhpTagsFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      6,
+      8,
+      13,
+      16,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+
+    // $warnings = $phpcsFile->getWarnings();
+    // $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[2][49][0]['source']);
+    // $this->assertEquals('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[2][49][0]['source']);
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ClosingPhpTagsFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClosingPhpTagsFixture.php
@@ -1,0 +1,18 @@
+<html>
+<h1>Page Title</h1>
+<?php
+$foo = 'hello';
+$blue = 'hello';
+$bar = 'bye'; // unused variable
+echo $foo;
+echo $baz; // undefined variable
+?>
+<p>More stuff</p>
+<?php
+$foo2 = 'hello';
+$bar2 = 'bye'; // unused variable
+echo $foo2;
+echo $blue;
+echo $baz2; // undefined variable
+?>
+</html>

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -12,7 +12,7 @@ class Helpers {
   /**
    * return int[]
    */
-  public static function getEmptyTokens(): array {
+  public static function getEmptyTokens() {
     return array_merge(
       array_values(Tokens::$emptyTokens),
       [

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -10,6 +10,19 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class Helpers {
   /**
+   * return int[]
+   */
+  public static function getEmptyTokens(): array {
+    return array_merge(
+      array_values(Tokens::$emptyTokens),
+      [
+        T_INLINE_HTML,
+        T_CLOSE_TAG,
+      ]
+    );
+  }
+
+  /**
    * @param int|bool $value
    *
    * @return ?int
@@ -146,7 +159,7 @@ class Helpers {
       return null;
     }
 
-    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonFunctionTokenTypes = self::getEmptyTokens();
     $nonFunctionTokenTypes[] = T_STRING;
     $nonFunctionTokenTypes[] = T_BITWISE_AND;
     $functionPtr = self::getIntOrNull($phpcsFile->findPrevious($nonFunctionTokenTypes, $startOfArguments - 1, null, true, null, true));
@@ -186,7 +199,7 @@ class Helpers {
   public static function getUseIndexForUseImport(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
-    $nonUseTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonUseTokenTypes = self::getEmptyTokens();
     $nonUseTokenTypes[] = T_VARIABLE;
     $nonUseTokenTypes[] = T_ELLIPSIS;
     $nonUseTokenTypes[] = T_COMMA;
@@ -215,7 +228,7 @@ class Helpers {
     $openPtr = Helpers::findContainingOpeningBracket($phpcsFile, $stackPtr);
     if (is_int($openPtr)) {
       // First non-whitespace thing and see if it's a T_STRING function name
-      $functionPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $openPtr - 1, null, true, null, true);
+      $functionPtr = $phpcsFile->findPrevious(self::getEmptyTokens(), $openPtr - 1, null, true, null, true);
       if (is_int($functionPtr) && $tokens[$functionPtr]['code'] === T_STRING) {
         return $functionPtr;
       }
@@ -242,7 +255,7 @@ class Helpers {
     }
 
     // $stackPtr is the function name, find our brackets after it
-    $openPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+    $openPtr = $phpcsFile->findNext(self::getEmptyTokens(), $stackPtr + 1, null, true, null, true);
     if (($openPtr === false) || ($tokens[$openPtr]['code'] !== T_OPEN_PARENTHESIS)) {
         return [];
     }
@@ -280,7 +293,7 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
 
     // Is the next non-whitespace an assignment?
-    $nextPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+    $nextPtr = $phpcsFile->findNext(self::getEmptyTokens(), $stackPtr + 1, null, true, null, true);
     if (is_int($nextPtr)
       && isset(Tokens::$assignmentTokens[$tokens[$nextPtr]['code']])
       // Ignore double arrow to prevent triggering on `foreach ( $array as $k => $v )`.
@@ -508,14 +521,14 @@ class Helpers {
       return false;
     }
     // Make sure next non-space token is an open parenthesis
-    $openParenIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+    $openParenIndex = $phpcsFile->findNext(self::getEmptyTokens(), $stackPtr + 1, null, true);
     if (! is_int($openParenIndex) || $tokens[$openParenIndex]['code'] !== T_OPEN_PARENTHESIS) {
       return false;
     }
     // Find the associated close parenthesis
     $closeParenIndex = $tokens[$openParenIndex]['parenthesis_closer'];
     // Make sure the next token is a fat arrow
-    $fatArrowIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closeParenIndex + 1, null, true);
+    $fatArrowIndex = $phpcsFile->findNext(self::getEmptyTokens(), $closeParenIndex + 1, null, true);
     if (! is_int($fatArrowIndex)) {
       return false;
     }
@@ -543,14 +556,14 @@ class Helpers {
       return null;
     }
     // Make sure next non-space token is an open parenthesis
-    $openParenIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+    $openParenIndex = $phpcsFile->findNext(self::getEmptyTokens(), $stackPtr + 1, null, true);
     if (! is_int($openParenIndex) || $tokens[$openParenIndex]['code'] !== T_OPEN_PARENTHESIS) {
       return null;
     }
     // Find the associated close parenthesis
     $closeParenIndex = $tokens[$openParenIndex]['parenthesis_closer'];
     // Make sure the next token is a fat arrow
-    $fatArrowIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closeParenIndex + 1, null, true);
+    $fatArrowIndex = $phpcsFile->findNext(self::getEmptyTokens(), $closeParenIndex + 1, null, true);
     if (! is_int($fatArrowIndex)) {
       return null;
     }
@@ -600,7 +613,7 @@ class Helpers {
     }
 
     // Find the assignment (equals sign) which, if this is a list assignment, should be the next non-space token
-    $assignPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $closePtr + 1, null, true);
+    $assignPtr = $phpcsFile->findNext(self::getEmptyTokens(), $closePtr + 1, null, true);
 
     // If the next token isn't an assignment, check for nested brackets because we might be a nested assignment
     if (! is_int($assignPtr) || $tokens[$assignPtr]['code'] !== T_EQUAL) {
@@ -715,7 +728,7 @@ class Helpers {
    */
   public static function isVariableInsideElseCondition(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
-    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonFunctionTokenTypes = self::getEmptyTokens();
     $nonFunctionTokenTypes[] = T_OPEN_PARENTHESIS;
     $nonFunctionTokenTypes[] = T_VARIABLE;
     $nonFunctionTokenTypes[] = T_ELLIPSIS;
@@ -837,7 +850,7 @@ class Helpers {
   public static function getLastNonEmptyTokenIndexInFile(File $phpcsFile) {
     $tokens = $phpcsFile->getTokens();
     foreach (array_reverse($tokens, true) as $index => $token) {
-      if (! in_array($token['code'], Tokens::$emptyTokens, true)) {
+      if (! in_array($token['code'], self::getEmptyTokens(), true)) {
         return $index;
       }
     }
@@ -921,7 +934,7 @@ class Helpers {
       return null;
     }
 
-    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonFunctionTokenTypes = self::getEmptyTokens();
     $functionPtr = self::getIntOrNull($phpcsFile->findPrevious($nonFunctionTokenTypes, $startOfArguments - 1, null, true, null, true));
     if (! is_int($functionPtr) || ! isset($tokens[$functionPtr]['code'])) {
       return null;
@@ -965,7 +978,7 @@ class Helpers {
    */
   public static function isVariableArrayPushShortcut(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
-    $nonFunctionTokenTypes = array_values(Tokens::$emptyTokens);
+    $nonFunctionTokenTypes = self::getEmptyTokens();
 
     $arrayPushOperatorIndex1 = self::getIntOrNull($phpcsFile->findNext($nonFunctionTokenTypes, $stackPtr + 1, null, true, null, true));
     if (! is_int($arrayPushOperatorIndex1)) {
@@ -1063,7 +1076,7 @@ class Helpers {
   public static function isTokenVariableVariable(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
 
-    $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+    $prev = $phpcsFile->findPrevious(self::getEmptyTokens(), ($stackPtr - 1), null, true);
     if ($prev === false) {
       return false;
     }
@@ -1074,7 +1087,7 @@ class Helpers {
       return false;
     }
 
-    $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+    $prevPrev = $phpcsFile->findPrevious(self::getEmptyTokens(), ($prev - 1), null, true);
     if ($prevPrev !== false && $tokens[$prevPrev]['code'] === T_DOLLAR) {
       return true;
     }


### PR DESCRIPTION
When mixing HTML and PHP, we must ignore the HTML tokens and the closing PHP tokens. This PR alters the parsing to consider them "empty" for the sake of all the functions that skip over empty space. Notably, this allows considering a closing HTML tag as the end of the global scope.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/232