### PR TITLE
Ignore double assignment by reference if second is inside condition

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -1040,6 +1040,7 @@ class VariableAnalysisTest extends BaseTestCase {
       34,
       35,
       43,
+      70,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -1059,6 +1059,7 @@ class VariableAnalysisTest extends BaseTestCase {
       26,
       34,
       35,
+      70,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
@@ -64,3 +64,11 @@ function somefunc($choice, &$arr1, &$arr_default) {
 
   echo $var;
 }
+
+function somefunc($choice, &$arr1, &$arr_default) {
+  if ($choice) {
+    $var = &$arr_default; // unused variable $var
+    $var = &$arr1;
+    echo $var;
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
@@ -54,3 +54,13 @@ function doubleUsedThenUsedAssignmentByReference() {
   $var = &$bee;
   return $var;
 }
+
+function somefunc($choice, &$arr1, &$arr_default) {
+  $var = &$arr_default;
+
+  if ($choice) {
+    $var = &$arr1;
+  }
+
+  echo $var;
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -105,20 +105,20 @@ class Helpers {
   /**
    * @param (int|string)[] $conditions
    *
-   * @return bool
+   * @return int|null
    */
-  public static function areConditionsWithinIfBeforeOthers(array $conditions) {
+  public static function getClosestIfPositionIfBeforeOtherConditions(array $conditions) {
     // Return true if the token conditions are within an if block before
     // they are within a class or function.
     $conditionsInsideOut = array_reverse($conditions, true);
     if (empty($conditions)) {
-      return false;
+      return null;
     }
     $scopeCode = reset($conditionsInsideOut);
     if ($scopeCode === T_IF) {
-      return true;
+      return key($conditionsInsideOut);
     }
-    return false;
+    return null;
   }
 
   /**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -103,6 +103,25 @@ class Helpers {
   }
 
   /**
+   * @param (int|string)[] $conditions
+   *
+   * @return bool
+   */
+  public static function areConditionsWithinIfBeforeOthers(array $conditions) {
+    // Return true if the token conditions are within an if block before
+    // they are within a class or function.
+    $conditionsInsideOut = array_reverse($conditions, true);
+    if (empty($conditions)) {
+      return false;
+    }
+    $scopeCode = reset($conditionsInsideOut);
+    if ($scopeCode === T_IF) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * @param File $phpcsFile
    * @param int $stackPtr
    *

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -105,7 +105,7 @@ class Helpers {
   /**
    * @param (int|string)[] $conditions
    *
-   * @return int|null
+   * @return int|string|null
    */
   public static function getClosestIfPositionIfBeforeOtherConditions(array $conditions) {
     // Return true if the token conditions are within an if block before

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -941,7 +941,12 @@ class VariableAnalysisSniff implements Sniff {
       // are inside a conditional block because in that case the condition may
       // never activate.
       $scopeInfo = $this->getOrCreateScopeInfo($currScope);
-      if (! Helpers::areConditionsWithinIfBeforeOthers($tokens[$referencePtr]['conditions'])) {
+      $ifPtr = Helpers::getClosestIfPositionIfBeforeOtherConditions($tokens[$referencePtr]['conditions']);
+      $lastAssignmentPtr = $varInfo->firstDeclared;
+      if (! $ifPtr && $lastAssignmentPtr) {
+        $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
+      }
+      if ($ifPtr && $lastAssignmentPtr && $ifPtr <= $lastAssignmentPtr) {
         $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
       }
       // The referenced variable may have a different name, but we don't

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -937,9 +937,13 @@ class VariableAnalysisSniff implements Sniff {
       Helpers::debug('processVariableAsAssignment: found reference variable');
       $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
       // If the variable was already declared, but was not yet read, it is
-      // unused because we're about to change the binding.
+      // unused because we're about to change the binding; that is, unless we
+      // are inside a conditional block because in that case the condition may
+      // never activate.
       $scopeInfo = $this->getOrCreateScopeInfo($currScope);
-      $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
+      if (! Helpers::areConditionsWithinIfBeforeOthers($tokens[$referencePtr]['conditions'])) {
+        $this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
+      }
       // The referenced variable may have a different name, but we don't
       // actually need to mark it as used in this case because the act of this
       // assignment will mark it used on the next token.


### PR DESCRIPTION
When there are two assignments by reference with use of the variable between them, we consider the first assignment to be unused since it is immediately replaced:

```php
$foo = &$bar; // unused
$foo = &$baz;
echo $foo;
```

However, if the second assignment is inside a condition, then we can't know if it will be used so we must ignore the warnings there:

```php
$foo = &$bar;
if ($something) {
  $foo = &$baz;
}
echo $foo;
```

This PR makes that change.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/231