### PR TITLE
Respect ignoring undefined variables in else blocks

### DIFF
--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -30,6 +30,39 @@ class IfConditionTest extends BaseTestCase {
       101,
       159,
       166,
+      176,
+      179,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testIfConditionWarningsWithValidUndefinedVariableNames() {
+    $fixtureFile = $this->getFixture('FunctionWithIfConditionFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUndefinedVariableNames',
+      'second'
+    );
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      15,
+      36,
+      47,
+      58,
+      70,
+      82,
+      98,
+      159,
+      166,
+      176,
+      179,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }
@@ -60,6 +93,39 @@ class IfConditionTest extends BaseTestCase {
       88,
       130,
       136,
+      152,
+      154,
+    ];
+    $this->assertEquals($expectedWarnings, $lines);
+  }
+
+  public function testInlineIfConditionWarningsWithValidUndefinedVariableNames() {
+    $fixtureFile = $this->getFixture('FunctionWithInlineIfConditionFixture.php');
+    $phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'validUndefinedVariableNames',
+      'second'
+    );
+    $phpcsFile->ruleset->setSniffProperty(
+      'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+      'allowUnusedParametersBeforeUsed',
+      'true'
+    );
+    $phpcsFile->process();
+    $lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+    $expectedWarnings = [
+      14,
+      34,
+      44,
+      54,
+      64,
+      74,
+      86,
+      130,
+      136,
+      152,
+      154,
     ];
     $this->assertEquals($expectedWarnings, $lines);
   }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithIfConditionFixture.php
@@ -167,3 +167,16 @@ function loopAndPushWithUndefinedArray($parts) {
   }
   return $suggestions;
 }
+
+function definedInsideElseIfBlockUndefinedInsideElseBlockDifferentName($first) {
+  $name = 'human';
+  if ($first) {
+    $words = "hello {$name}";
+  } elseif ($name) {
+    $third = true; // unused variable $third
+  } else {
+    $words = "bye {$name}";
+    echo $third; // undefined variable $third
+  }
+  echo $words;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
@@ -143,3 +143,14 @@ function ifElseConditionWithInlineAssignAndUseInsideElse() {
   else
     echo $q;
 }
+
+function definedInsideElseIfBlockUndefinedInsideElseBlockDifferentName($first) {
+  $name = 'human';
+  if ($first)
+    $words = "hello {$name}";
+  elseif ($name)
+    $third = true; // unused variable $third
+  else
+    echo $third; // undefined variable $third
+  echo $words;
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1518,8 +1518,10 @@ class VariableAnalysisSniff implements Sniff {
     }
 
     if (count($assignmentsInsideAttachedBlocks) === count($allAssignmentIndices)) {
-      Helpers::debug("variable $varName inside else looks undefined");
-      $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
+      if (! $varInfo->ignoreUndefined) {
+        Helpers::debug("variable $varName inside else looks undefined");
+        $this->warnAboutUndefinedVariable($phpcsFile, $varName, $stackPtr);
+      }
       return;
     }
 


### PR DESCRIPTION
In https://github.com/sirbrillig/phpcs-variable-analysis/pull/189 we introduced special handling for variables used in `else` blocks, but since it didn't use the normal processing system, we broke respecting the existing options for ignoring undefined variables like `allowUndefinedVariablesInFileScope`, `validUndefinedVariableNames`, and `validUndefinedVariableRegexp`. This PR makes sure that the special handling respects those options.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/238