### PR TITLE
Update for Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ VariableAnalysis requires PHP 5.4 or higher and [PHP CodeSniffer](https://github
 
 This is the easiest method.
 
-First, install [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer) for your project if you have not already. This will also install PHPCS.
+First, install [phpcodesniffer-composer-installer](https://github.com/PHPCSStandards/composer-installer) for your project if you have not already. This will also install PHPCS.
 
 ```
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev dealerdirect/phpcodesniffer-composer-installer
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
         "source": "https://github.com/sirbrillig/phpcs-variable-analysis"
     },
     "config": {
-        "sort-order": true
+        "sort-order": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Using the `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is recommended to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit:
* Adds the necessary configuration for that to the `composer.json` for this project.
* Adds the CLI command to set those permissions to the installation instructions for consumer projects.

Includes updating the URL references to the plugin to point to the new home of the plugin. (see [upstream issue #146](https://github.com/PHPCSStandards/composer-installer/issues/146))

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution