### PR TITLE
Ruleset: various minor improvements

### DIFF
--- a/VariableAnalysis/ruleset.xml
+++ b/VariableAnalysis/ruleset.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-<ruleset name="VariableAnalysis">
-  <description>Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problematic variable use.</description>
-   <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="VariableAnalysis" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    <description>Plugin for PHP_CodeSniffer static analysis tool that adds analysis of problematic variable use.</description>
 </ruleset>


### PR DESCRIPTION
* Add XML schema references.
* Remove the sniff reference. A Ruleset for a registered standard will automatically include all sniffs in that standard, so no need to explicitly include the sniff.
* Consistently use four space indent.