### PR TITLE
PHPStan: update to run against current version

### DIFF
--- a/VariableAnalysis/Lib/Constants.php
+++ b/VariableAnalysis/Lib/Constants.php
@@ -12,7 +12,7 @@ class Constants {
    *  ones which can be passed an undefined variable (eg: `$matches` in
    *  `preg_match`) and will define that variable.
    *
-   *  @return array[]
+   *  @return array<string, array<int|string>>
    */
   public static function getPassByReferenceFunctions() {
     return [
@@ -236,7 +236,7 @@ class Constants {
   }
 
   /**
-   * @return array[]
+   * @return array<string, array<int>>
    */
   public static function getWordPressPassByReferenceFunctions() {
     return [

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -485,7 +485,7 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
     $token = $tokens[$stackPtr];
     $openParenIndices = isset($token['nested_parenthesis']) ? $token['nested_parenthesis'] : [];
-    if ($openParenIndices === []) {
+    if (empty($openParenIndices)) {
       return false;
     }
     $openParenPtr = $openParenIndices[0];

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -10,7 +10,7 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class Helpers {
   /**
-   * return int[]
+   * @return array<int|string>
    */
   public static function getPossibleEndOfFileTokens() {
     return array_merge(
@@ -477,7 +477,7 @@ class Helpers {
     $tokens = $phpcsFile->getTokens();
     $token = $tokens[$stackPtr];
     $openParenIndices = isset($token['nested_parenthesis']) ? $token['nested_parenthesis'] : [];
-    if ($openParenIndices) {
+    if ($openParenIndices === []) {
       return false;
     }
     $openParenPtr = $openParenIndices[0];
@@ -561,7 +561,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return ?array
+   * @return ?array<string, int>
    */
   public static function getArrowFunctionOpenClose(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -613,7 +613,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $listOpenerIndex
    *
-   * @return ?array
+   * @return ?array<int>
    */
   public static function getListAssignments(File $phpcsFile, $listOpenerIndex) {
     $tokens = $phpcsFile->getTokens();

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -259,7 +259,7 @@ class Helpers {
    * @param File $phpcsFile
    * @param int $stackPtr
    *
-   * @return array[]
+   * @return array<int, array<int>>
    */
   public static function findFunctionCallArguments(File $phpcsFile, $stackPtr) {
     $tokens = $phpcsFile->getTokens();
@@ -291,13 +291,21 @@ class Helpers {
     while (is_int($nextPtr)) {
       if (Helpers::findContainingOpeningBracket($phpcsFile, $nextPtr) == $openPtr) {
         // Comma is at our level of brackets, it's an argument delimiter.
-        array_push($argPtrs, range($lastArgComma + 1, $nextPtr - 1));
+        $range = range($lastArgComma + 1, $nextPtr - 1);
+        $range = array_filter($range, function($element) {
+          return is_int($element);
+        });
+        array_push($argPtrs, $range);
         $lastArgComma = $nextPtr;
       }
       $lastPtr = $nextPtr;
       $nextPtr = $phpcsFile->findNext([T_COMMA], $lastPtr + 1, $closePtr);
     }
-    array_push($argPtrs, range($lastArgComma + 1, $closePtr - 1));
+    $range = range($lastArgComma + 1, $closePtr - 1);
+    $range = array_filter($range, function($element) {
+      return is_int($element);
+    });
+    array_push($argPtrs, $range);
 
     return $argPtrs;
   }

--- a/VariableAnalysis/Lib/ScopeInfo.php
+++ b/VariableAnalysis/Lib/ScopeInfo.php
@@ -27,6 +27,10 @@ class ScopeInfo {
    */
   public $variables = [];
 
+  /**
+   * @param int      $scopeStartIndex
+   * @param int|null $scopeEndIndex
+   */
   public function __construct($scopeStartIndex, $scopeEndIndex = null) {
     $this->scopeStartIndex = $scopeStartIndex;
     $this->scopeEndIndex = $scopeEndIndex;

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -26,7 +26,7 @@ class VariableInfo {
   public $typeHint;
 
   /**
-   * @var int | null
+   * @var int|null
    */
   public $referencedVariableScope;
 
@@ -98,6 +98,9 @@ class VariableInfo {
     ScopeType::BOUND  => 'bound variable',
   );
 
+  /**
+   * @param string $varName
+   */
   public function __construct($varName) {
     $this->name = $varName;
   }

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -44,21 +44,21 @@ class VariableInfo {
    *
    * Assignment by reference is also a declaration and not an initialization.
    *
-   * @var int
+   * @var int|null
    */
   public $firstDeclared;
 
   /**
    * Stack pointer of first initialization
    *
-   * @var int
+   * @var int|null
    */
   public $firstInitialized;
 
   /**
    * Stack pointer of first read
    *
-   * @var int
+   * @var int|null
    */
   public $firstRead;
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -448,7 +448,7 @@ class VariableAnalysisSniff implements Sniff {
       }
     }
 
-    if (!isset($varInfo->scopeType)) {
+    if (empty($varInfo->scopeType)) {
       $varInfo->scopeType = ScopeType::LOCAL;
     }
     $varInfo->allAssignments[] = $stackPtr;
@@ -475,7 +475,7 @@ class VariableAnalysisSniff implements Sniff {
     Helpers::debug("marking variable '{$varName}' declared in scope starting at token", $currScope);
     $varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
 
-    if (isset($varInfo->scopeType)) {
+    if (! empty($varInfo->scopeType)) {
       if (($permitMatchingRedeclaration === false) || ($varInfo->scopeType !== $scopeType)) {
         //  Issue redeclaration/reuse warning
         //  Note: we check off scopeType not firstDeclared, this is so that
@@ -1579,7 +1579,7 @@ class VariableAnalysisSniff implements Sniff {
   /**
    * @param File $phpcsFile
    * @param int $stackPtr
-   * @param array[] $arguments The stack pointers of each argument
+   * @param array<int, array<int>> $arguments The stack pointers of each argument
    * @param int $currScope
    *
    * @return void

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -182,7 +182,7 @@ class VariableAnalysisSniff implements Sniff {
   /**
    * @param string $functionName
    *
-   * @return string[]
+   * @return array<int|string>
    */
   private function getPassByReferenceFunction($functionName) {
     $passByRefFunctions = Constants::getPassByReferenceFunctions();
@@ -620,6 +620,7 @@ class VariableAnalysisSniff implements Sniff {
    * @param File $phpcsFile
    * @param int $stackPtr
    * @param string $varName
+   * @param int $outerScope
    *
    * @return void
    */

--- a/composer.circleci.json
+++ b/composer.circleci.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "test": "./vendor/bin/phpunit
+        "test": "./vendor/bin/phpunit"
     },
     "require" : {
         "php" : ">=5.4.0",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
         "sirbrillig/phpcs-import-detection": "^1.1",
-        "phpstan/phpstan": "^0.11.8",
+        "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,11 @@
 parameters:
   level: 7
   reportUnmatchedIgnoredErrors: false
-  autoload_files:
+  bootstrapFiles:
     - %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
   paths:
     - %currentWorkingDirectory%/VariableAnalysis/
-  excludes_analyse:
+  excludePaths:
     - %currentWorkingDirectory%/Tests/
   ignoreErrors:
     - '~^Constant T_\w+ not found.$~'


### PR DESCRIPTION
### PHPStan: update to run against current version

The PHPStan version being used is wildly out of date, which makes it not very effective.

This update the PHPStan version used to the latest release and updates the PHPStan configuration to match.

Refs:
* https://github.com/phpstan/phpstan/releases
* https://github.com/phpstan/phpstan/releases/tag/1.0.0
* https://phpstan.org/blog/phpstan-1-0-released

### Docs: improve type declarations to help PHPStan

---

Note: even after the fixes from the second commit, PHPStan is still flagging 12 issues. I leave it up to you @sirbrillig to decide what you want to do with those.