### PR TITLE
PHP 8.2 | Fix deprecated embedded variables in text strings

### DIFF
--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -919,7 +919,7 @@ class VariableAnalysisSniff implements Sniff {
    * @return void
    */
   protected function processVariableAsAssignment(File $phpcsFile, $stackPtr, $varName, $currScope) {
-    Helpers::debug("processVariableAsAssignment: starting for '${varName}'");
+    Helpers::debug("processVariableAsAssignment: starting for '{$varName}'");
     $assignPtr = Helpers::getNextAssignPointer($phpcsFile, $stackPtr);
     if (! is_int($assignPtr)) {
       return;


### PR DESCRIPTION
PHP 8.2 will deprecate two of the four currently supported syntaxes for embedding variables in double quoted text string/heredocs.

This libary contains one such use of an embedded variable using braces after the dollar sign (`"${foo}"`), which is one of the deprecated forms.

This commit fixes this.

Refs:
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation