### PR TITLE
CS/QA: align different data in `@param` tags

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -33,7 +33,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -44,7 +44,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return int
 	 */
@@ -55,7 +55,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -123,7 +123,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -133,7 +133,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -152,7 +152,7 @@ class Helpers {
 	 * `getFunctionIndexForFunctionCallArgument`.
 	 *
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -199,7 +199,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -211,7 +211,7 @@ class Helpers {
 	 * Find the token index of the "use" for a token inside a function use import
 	 *
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -237,7 +237,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -257,7 +257,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return array<int, array<int>>
 	 */
@@ -312,7 +312,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -342,9 +342,9 @@ class Helpers {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
-	 * @param string $varName (optional) if it differs from the normalized 'content' of the token at $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
+	 * @param string $varName   (optional) if it differs from the normalized 'content' of the token at $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -395,7 +395,7 @@ class Helpers {
 	 * arrow function and also check its enclosing scope separately.
 	 *
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -439,7 +439,7 @@ class Helpers {
 	 * enclosing function's scope, which may be incorrect.
 	 *
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -477,7 +477,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -494,7 +494,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -517,7 +517,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -535,7 +535,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -567,7 +567,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?array<string, int>
 	 */
@@ -619,7 +619,7 @@ class Helpers {
 	 * Return a list of indices for variables assigned within a list assignment
 	 *
 	 * @param File $phpcsFile
-	 * @param int $listOpenerIndex
+	 * @param int  $listOpenerIndex
 	 *
 	 * @return ?array<int>
 	 */
@@ -685,7 +685,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return string[]
 	 */
@@ -749,7 +749,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -777,7 +777,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -811,7 +811,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return int[]
 	 */
@@ -852,7 +852,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $scopeStartIndex
+	 * @param int  $scopeStartIndex
 	 *
 	 * @return int
 	 */
@@ -889,7 +889,7 @@ class Helpers {
 
 	/**
 	 * @param VariableInfo $varInfo
-	 * @param ScopeInfo $scopeInfo
+	 * @param ScopeInfo    $scopeInfo
 	 *
 	 * @return bool
 	 */
@@ -914,9 +914,9 @@ class Helpers {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File         $phpcsFile
 	 * @param VariableInfo $varInfo
-	 * @param ScopeInfo $scopeInfo
+	 * @param ScopeInfo    $scopeInfo
 	 *
 	 * @return bool
 	 */
@@ -947,7 +947,7 @@ class Helpers {
 	 * Find the index of the function keyword for a token in a function call's arguments
 	 *
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return ?int
 	 */
@@ -976,7 +976,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -1001,7 +1001,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -1038,7 +1038,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -1059,7 +1059,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -1077,7 +1077,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -1098,7 +1098,7 @@ class Helpers {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -201,7 +201,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return void
 	 */
@@ -255,7 +255,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $scopeStartIndex
+	 * @param int  $scopeStartIndex
 	 *
 	 * @return void
 	 */
@@ -272,7 +272,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return void
 	 */
@@ -301,7 +301,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -360,7 +360,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return VariableInfo|null
 	 */
@@ -371,7 +371,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return VariableInfo
 	 */
@@ -411,8 +411,8 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $stackPtr
-	 * @param int $currScope
+	 * @param int    $stackPtr
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -431,8 +431,8 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $stackPtr
-	 * @param int $currScope
+	 * @param int    $stackPtr
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -455,12 +455,12 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param string $varName
-	 * @param string $scopeType
+	 * @param string  $varName
+	 * @param string  $scopeType
 	 * @param ?string $typeHint
-	 * @param int $stackPtr
-	 * @param int $currScope
-	 * @param ?bool $permitMatchingRedeclaration
+	 * @param int     $stackPtr
+	 * @param int     $currScope
+	 * @param ?bool   $permitMatchingRedeclaration
 	 *
 	 * @return void
 	 */
@@ -508,9 +508,9 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param string $message
-	 * @param int $stackPtr
-	 * @param string $code
+	 * @param string   $message
+	 * @param int      $stackPtr
+	 * @param string   $code
 	 * @param string[] $data
 	 *
 	 * @return void
@@ -529,8 +529,8 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $stackPtr
-	 * @param int $currScope
+	 * @param int    $stackPtr
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -544,8 +544,8 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param string $varName
-	 * @param int $stackPtr
-	 * @param int $currScope
+	 * @param int    $stackPtr
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -565,10 +565,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File   $phpcsFile
 	 * @param string $varName
-	 * @param int $stackPtr
-	 * @param int $currScope
+	 * @param int    $stackPtr
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -595,7 +595,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return void
 	 */
@@ -617,10 +617,10 @@ class VariableAnalysisSniff implements Sniff {
 	 *
 	 * This does not include variables imported by a "use" statement.
 	 *
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $outerScope
+	 * @param int    $outerScope
 	 *
 	 * @return void
 	 */
@@ -654,10 +654,10 @@ class VariableAnalysisSniff implements Sniff {
 	/**
 	 * Process a variable if it is inside a function's "use" import
 	 *
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $outerScope The start of the scope outside the function definition
+	 * @param int    $outerScope The start of the scope outside the function definition
 	 *
 	 * @return void
 	 */
@@ -700,7 +700,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -737,10 +737,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -768,8 +768,8 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
 	 *
 	 * @return bool
@@ -837,7 +837,7 @@ class VariableAnalysisSniff implements Sniff {
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
@@ -869,8 +869,8 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
 	 *
 	 * @return bool
@@ -912,10 +912,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -974,10 +974,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1009,10 +1009,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1051,10 +1051,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1078,10 +1078,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1146,10 +1146,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1202,10 +1202,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1269,10 +1269,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return bool
 	 */
@@ -1312,7 +1312,7 @@ class VariableAnalysisSniff implements Sniff {
 	 * `processCompact`. They have the same purpose as this function, though.
 	 *
 	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
-	 * @param int $stackPtr  The position where the token was found.
+	 * @param int  $stackPtr  The position where the token was found.
 	 *
 	 * @return void
 	 */
@@ -1477,10 +1477,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File   $phpcsFile
+	 * @param int    $stackPtr
 	 * @param string $varName
-	 * @param int $currScope
+	 * @param int    $currScope
 	 *
 	 * @return void
 	 */
@@ -1537,7 +1537,7 @@ class VariableAnalysisSniff implements Sniff {
 	 * result only in one call for the string.
 	 *
 	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
-	 * @param int $stackPtr  The position where the double quoted string was found.
+	 * @param int  $stackPtr  The position where the double quoted string was found.
 	 *
 	 * @return void
 	 */
@@ -1577,10 +1577,10 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File                   $phpcsFile
+	 * @param int                    $stackPtr
 	 * @param array<int, array<int>> $arguments The stack pointers of each argument
-	 * @param int $currScope
+	 * @param int                    $currScope
 	 *
 	 * @return void
 	 */
@@ -1633,7 +1633,7 @@ class VariableAnalysisSniff implements Sniff {
 	 * Called to process variables named in a call to compact().
 	 *
 	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
-	 * @param int $stackPtr  The position where the call to compact() was found.
+	 * @param int  $stackPtr  The position where the call to compact() was found.
 	 *
 	 * @return void
 	 */
@@ -1654,7 +1654,7 @@ class VariableAnalysisSniff implements Sniff {
 	 * $stackPtr is the scope conditional, not the closing curly brace.
 	 *
 	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
-	 * @param int $stackPtr  The position of the scope conditional.
+	 * @param int  $stackPtr  The position of the scope conditional.
 	 *
 	 * @return void
 	 */
@@ -1669,9 +1669,9 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File         $phpcsFile
 	 * @param VariableInfo $varInfo
-	 * @param ScopeInfo $scopeInfo
+	 * @param ScopeInfo    $scopeInfo
 	 *
 	 * @return void
 	 */
@@ -1717,7 +1717,7 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File         $phpcsFile
 	 * @param VariableInfo $varInfo
 	 *
 	 * @return void
@@ -1738,9 +1738,9 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File   $phpcsFile
 	 * @param string $varName
-	 * @param int $stackPtr
+	 * @param int    $stackPtr
 	 *
 	 * @return void
 	 */
@@ -1754,9 +1754,9 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File   $phpcsFile
 	 * @param string $varName
-	 * @param int $stackPtr
+	 * @param int    $stackPtr
 	 *
 	 * @return void
 	 */
@@ -1770,9 +1770,9 @@ class VariableAnalysisSniff implements Sniff {
 	}
 
 	/**
-	 * @param File $phpcsFile
+	 * @param File   $phpcsFile
 	 * @param string $varName
-	 * @param int $stackPtr
+	 * @param int    $stackPtr
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Effectively treat the information in a `@param` tag as columns to be aligned:
```
@param dataType $variableName Description
```