### PR TITLE
Tests: declare error codes as constants in the BaseTestCase

### DIFF
--- a/Tests/BaseTestCase.php
+++ b/Tests/BaseTestCase.php
@@ -10,6 +10,13 @@ class BaseTestCase extends TestCase
 {
 	const STANDARD_NAME = 'VariableAnalysis';
 
+	const REDECLARATION_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.VariableRedeclaration';
+	const SELF_OUTSIDE_CLASS_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.SelfOutsideClass';
+	const STATIC_OUSIDE_CLASS_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.StaticOutsideClass';
+	const UNDEFINED_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable';
+	const UNSET_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedUnsetVariable';
+	const UNUSED_ERROR_CODE = 'VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable';
+
 	public function prepareLocalFileForSniffs($fixtureFile)
 	{
 		$sniffFile = __DIR__ . '/../VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php';

--- a/Tests/VariableAnalysisSniff/ArrayAssignmentShortcutTest.php
+++ b/Tests/VariableAnalysisSniff/ArrayAssignmentShortcutTest.php
@@ -28,9 +28,9 @@ class ArrayAssignmentShortcutTest extends BaseTestCase
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[21][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[27][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[28][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[29][10][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[21][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[27][5][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[28][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[29][10][0]['source']);
 	}
 }

--- a/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
+++ b/Tests/VariableAnalysisSniff/ClosingPhpTagsTest.php
@@ -26,9 +26,9 @@ class ClosingPhpTagsTest extends BaseTestCase
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
 		$phpcsFile->process();
 		$warnings = $phpcsFile->getWarnings();
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[6][1][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[8][6][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[13][1][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[16][6][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[6][1][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[8][6][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[13][1][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[16][6][0]['source']);
 	}
 }

--- a/Tests/VariableAnalysisSniff/UnsetTest.php
+++ b/Tests/VariableAnalysisSniff/UnsetTest.php
@@ -26,7 +26,7 @@ class UnsetTest extends BaseTestCase
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedUnsetVariable', $warnings[6][7][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedUnsetVariable', $warnings[11][9][0]['source']);
+		$this->assertSame(self::UNSET_ERROR_CODE, $warnings[6][7][0]['source']);
+		$this->assertSame(self::UNSET_ERROR_CODE, $warnings[11][9][0]['source']);
 	}
 }

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -552,15 +552,15 @@ class VariableAnalysisTest extends BaseTestCase
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[2][49][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[7][23][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[10][54][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[14][52][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[19][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[23][23][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[26][66][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[36][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable', $warnings[36][23][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[2][49][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[7][23][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[10][54][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[14][52][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[19][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[23][23][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[26][66][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[36][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[36][23][0]['source']);
 	}
 
 	public function testTraitAllowsThis()
@@ -696,13 +696,13 @@ class VariableAnalysisTest extends BaseTestCase
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[4][43][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[16][52][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[27][60][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[39][42][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[39][51][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[72][5][0]['source']);
-		$this->assertSame('VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable', $warnings[73][5][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[4][43][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[16][52][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[27][60][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[39][42][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[39][51][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[72][5][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[73][5][0]['source']);
 	}
 
 	public function testValidUnusedVariableNamesIgnoresUnusedVariables()


### PR DESCRIPTION
This primarily makes the tests more stable by removing typo-prone, duplicate hard-coded information, but it also fixed a number of line length issues.