### PR TITLE
Allow for loop increment expression to use variable defined inside loop

### DIFF
--- a/Tests/VariableAnalysisSniff/ForLoopTest.php
+++ b/Tests/VariableAnalysisSniff/ForLoopTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class ForLoopTest extends BaseTestCase
+{
+	public function testFunctionWithForLoopWarningsReportsCorrectLines()
+	{
+		$fixtureFile = $this->getFixture('FunctionWithForLoopFixture.php');
+		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+		$phpcsFile->process();
+		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedWarnings = [
+			22,
+			65,
+			80,
+			94,
+			110,
+			112,
+			113,
+			118,
+			123,
+			129,
+		];
+		$this->assertSame($expectedWarnings, $lines);
+	}
+
+	public function testFunctionWithForLoopWarningsHasCorrectSniffCodes()
+	{
+		$fixtureFile = $this->getFixture('FunctionWithForLoopFixture.php');
+		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+		$phpcsFile->process();
+		$warnings = $phpcsFile->getWarnings();
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[22][17][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[65][16][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[80][16][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[94][5][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[110][7][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[112][7][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[113][16][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[118][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[123][5][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[129][14][0]['source']);
+	}
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
@@ -1,0 +1,139 @@
+<?php
+
+function defineIncrementBeforeLoop($fp, $string) {
+  $count = 10;
+  for (
+    $written = 0;
+    $written < strlen($string);
+    $written += $count
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  return $written;
+}
+
+function defineIncrementAfterLoop($fp, $string) {
+  for (
+    $written = 0;
+    $written < strlen($string);
+    $written += $count // Undefined variable $count
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  $count = 10; // This is an unused variable, but it's hard to tell because it has been read above in the same scope.
+  return $written;
+}
+
+function defineIncrementInsideLoop($fp, $string) {
+  for (
+    $written = 0;
+    $written < strlen($string);
+    $written += $fwrite
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  return $written;
+}
+
+function defineConditionBeforeLoop($fp, $string) {
+  $count = 10;
+  for (
+    $written = 0;
+    $written < $count;
+    $written += 1
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  return $written;
+}
+
+function defineConditionAfterLoop($fp, $string) {
+  for (
+    $written = 0;
+    $written < $count; // Undefined variable $count
+    $written += 1
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  $count = 10;
+  return $written;
+}
+
+function defineConditionInsideLoop($fp, $string) {
+  for (
+    $written = 0;
+    $written < $fwrite; // Undefined variable $fwrite
+    $written += 1
+  ) {
+    $fwrite = fwrite($fp, substr($string, $written));
+    if ($fwrite === false) {
+      return $written;
+    }
+  }
+  return $written;
+}
+
+function unusedInitializer($fp, $string) {
+  $written = 0;
+  for (
+    $foo = 0; // Unused variable $foo
+    ;
+    $written += 1
+  ) {
+    fwrite($fp, substr($string, $written));
+    if ($written > 10) {
+      break;
+    }
+  }
+}
+
+function closureInsideLoopInit() {
+  for (
+    $closure = function(
+      $a,
+      $b,
+      $c // Unused variable $c
+    ) {
+      $m = 1; // Unused variable $m
+      var_dump($i); // Undefined variable $i
+      return $a * $b;
+    },
+    $a = 0,
+    $b = 0,
+    $c = 0, // Unused variable $c
+    $i = 10;
+  $closure($a, $b, 4) < $i;
+  $i++,
+    $a++,
+    $t++, // Undefined variable $t
+    $b++
+  )
+  {
+    var_dump($a);
+    var_dump($b);
+    var_dump($m); // Undefined variable $m
+  }
+}
+
+function veryBoringForLoop() {
+  for (
+    ;
+    ;
+  ) {
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
@@ -137,3 +137,17 @@ function veryBoringForLoop() {
   ) {
   }
 }
+
+function reallySmallForLoop() {
+  for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+}
+
+function colonSyntaxForLoop() {
+  for ($i = 0; $i < 10; $i++):
+    print $i;
+  endfor;
+}
+
+function forLoopWithOneStatement() {
+  for ($i = 0; $i < 10; $i++) echo $i;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
@@ -148,6 +148,17 @@ function colonSyntaxForLoop() {
   endfor;
 }
 
+function colonSyntaxForLoopAndLateDefinition() {
+  for ($i = 0; $i < 10; var_dump($foo), $i++):
+    $foo = 'hello';
+    print $i;
+  endfor;
+}
+
 function forLoopWithOneStatement() {
   for ($i = 0; $i < 10; $i++) echo $i;
+}
+
+function forLoopWithOneStatementAndLateDefinition() {
+  for ($i = 0; $i < 10; var_dump($foo), $i++) $foo = 'hello';
 }

--- a/VariableAnalysis/Lib/ForLoopInfo.php
+++ b/VariableAnalysis/Lib/ForLoopInfo.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace VariableAnalysis\Lib;
+
+/**
+ * Holds details of a for loop.
+ */
+class ForLoopInfo
+{
+	/**
+	 * The position of the `for` token.
+	 *
+	 * @var int
+	 */
+	public $forIndex;
+
+	/**
+	 * The position of the initialization expression opener for the loop.
+	 *
+	 * @var int
+	 */
+	public $initStart;
+
+	/**
+	 * The position of the initialization expression closer for the loop.
+	 *
+	 * @var int
+	 */
+	public $initEnd;
+
+	/**
+	 * The position of the condition expression opener for the loop.
+	 *
+	 * @var int
+	 */
+	public $conditionStart;
+
+	/**
+	 * The position of the condition expression closer for the loop.
+	 *
+	 * @var int
+	 */
+	public $conditionEnd;
+
+	/**
+	 * The position of the increment expression opener for the loop.
+	 *
+	 * @var int
+	 */
+	public $incrementStart;
+
+	/**
+	 * The position of the increment expression closer for the loop.
+	 *
+	 * @var int
+	 */
+	public $incrementEnd;
+
+	/**
+	 * The position of the block opener for the loop.
+	 *
+	 * @var int
+	 */
+	public $blockStart;
+
+	/**
+	 * The position of the block closer for the loop.
+	 *
+	 * @var int
+	 */
+	public $blockEnd;
+
+	/**
+	 * Any variables defined inside the third expression of the loop.
+	 *
+	 * The key is the variable index.
+	 *
+	 * @var array<int, \VariableAnalysis\Lib\VariableInfo>
+	 */
+	public $incrementVariables = [];
+
+	/**
+	 * @param int $forIndex
+	 * @param int $blockStart
+	 * @param int $blockEnd
+	 * @param int $initStart
+	 * @param int $initEnd
+	 * @param int $conditionStart
+	 * @param int $conditionEnd
+	 * @param int $incrementStart
+	 * @param int $incrementEnd
+	 */
+	public function __construct(
+		$forIndex,
+		$blockStart,
+		$blockEnd,
+		$initStart,
+		$initEnd,
+		$conditionStart,
+		$conditionEnd,
+		$incrementStart,
+		$incrementEnd
+	) {
+		$this->forIndex = $forIndex;
+		$this->blockStart = $blockStart;
+		$this->blockEnd = $blockEnd;
+		$this->initStart = $initStart;
+		$this->initEnd = $initEnd;
+		$this->conditionStart = $conditionStart;
+		$this->conditionEnd = $conditionEnd;
+		$this->incrementStart = $incrementStart;
+		$this->incrementEnd = $incrementEnd;
+	}
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1193,10 +1193,18 @@ class Helpers
 		$token = $tokens[$stackPtr];
 		$forIndex = $stackPtr;
 		$blockStart = $token['parenthesis_closer'];
-		$blockEnd = $token['parenthesis_closer'];
 		if (isset($token['scope_opener'])) {
 		  $blockStart = $token['scope_opener'];
 		  $blockEnd = $token['scope_closer'];
+		} else {
+			// Some for loop blocks will not have scope positions because it they are
+			// inline (no curly braces) so we have to find the end of their scope by
+			// looking for the end of the next statement.
+			$nextSemicolonIndex = $phpcsFile->findNext([T_SEMICOLON], $token['parenthesis_closer']);
+			if (! is_int($nextSemicolonIndex)) {
+				$nextSemicolonIndex = $token['parenthesis_closer'] + 1;
+			}
+		  $blockEnd = $nextSemicolonIndex;
 		}
 		$initStart = intval($token['parenthesis_opener']) + 1;
 		$initEnd = null;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -143,12 +143,17 @@ class Helpers
 	}
 
 	/**
+	 * Return true if the token is inside the arguments of a function call.
+	 *
+	 * For example, the variable `$foo` in `doSomething($foo)` is inside the
+	 * arguments to the call to `doSomething()`.
+	 *
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr
 	 *
 	 * @return bool
 	 */
-	public static function isTokenInsideFunctionCall(File $phpcsFile, $stackPtr)
+	public static function isTokenInsideFunctionCallArgument(File $phpcsFile, $stackPtr)
 	{
 		return is_int(self::getFunctionIndexForFunctionCallArgument($phpcsFile, $stackPtr));
 	}
@@ -986,6 +991,9 @@ class Helpers
 	/**
 	 * Find the index of the function keyword for a token in a function call's arguments
 	 *
+	 * For the variable `$foo` in the expression `doSomething($foo)`, this will
+	 * return the index of the `doSomething` token.
+	 *
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr
 	 *
@@ -1009,7 +1017,10 @@ class Helpers
 		if (! is_int($functionPtr) || ! isset($tokens[$functionPtr]['code'])) {
 			return null;
 		}
-		if ($tokens[$functionPtr]['code'] === 'function' || ($tokens[$functionPtr]['content'] === 'fn' && self::isArrowFunction($phpcsFile, $functionPtr))) {
+		if ($tokens[$functionPtr]['content'] === 'function' || ($tokens[$functionPtr]['content'] === 'fn' && self::isArrowFunction($phpcsFile, $functionPtr))) {
+			return null;
+		}
+		if (! empty($tokens[$functionPtr]['scope_opener'])) {
 			return null;
 		}
 		return $functionPtr;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -637,7 +637,7 @@ class Helpers
 			T_CLOSE_CURLY_BRACKET,
 			T_CLOSE_SHORT_ARRAY,
 		];
-		$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $fatArrowIndex  + 1);
+		$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $fatArrowIndex	+ 1);
 		if (! is_int($scopeCloserIndex)) {
 			return null;
 		}
@@ -1194,8 +1194,8 @@ class Helpers
 		$forIndex = $stackPtr;
 		$blockStart = $token['parenthesis_closer'];
 		if (isset($token['scope_opener'])) {
-		  $blockStart = $token['scope_opener'];
-		  $blockEnd = $token['scope_closer'];
+			$blockStart = $token['scope_opener'];
+			$blockEnd = $token['scope_closer'];
 		} else {
 			// Some for loop blocks will not have scope positions because it they are
 			// inline (no curly braces) so we have to find the end of their scope by
@@ -1204,7 +1204,7 @@ class Helpers
 			if (! is_int($nextSemicolonIndex)) {
 				$nextSemicolonIndex = $token['parenthesis_closer'] + 1;
 			}
-		  $blockEnd = $nextSemicolonIndex;
+			$blockEnd = $nextSemicolonIndex;
 		}
 		$initStart = intval($token['parenthesis_opener']) + 1;
 		$initEnd = null;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1192,8 +1192,12 @@ class Helpers
 		$tokens = $phpcsFile->getTokens();
 		$token = $tokens[$stackPtr];
 		$forIndex = $stackPtr;
-		$blockStart = $token['scope_opener'];
-		$blockEnd = $token['scope_closer'];
+		$blockStart = $token['parenthesis_closer'];
+		$blockEnd = $token['parenthesis_closer'];
+		if (isset($token['scope_opener'])) {
+		  $blockStart = $token['scope_opener'];
+		  $blockEnd = $token['scope_closer'];
+		}
 		$initStart = intval($token['parenthesis_opener']) + 1;
 		$initEnd = null;
 		$conditionStart = null;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -170,6 +170,7 @@ class VariableAnalysisSniff implements Sniff
 			T_SEMICOLON,
 			T_CLOSE_PARENTHESIS,
 			T_FOR,
+			T_ENDFOR,
 		];
 		if (defined('T_FN')) {
 			$types[] = T_FN;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -27,6 +27,13 @@ class VariableAnalysisSniff implements Sniff
 	private $scopeManager;
 
 	/**
+	 * A list of for loops, keyed by the index of their first token in this file.
+	 *
+	 * @var array<int, \VariableAnalysis\Lib\ForLoopInfo>
+	 */
+	private $forLoops = [];
+
+	/**
 	 * A list of custom functions which pass in variables to be initialized by
 	 * reference (eg `preg_match()`) and therefore should not require those
 	 * variables to be defined ahead of time. The list is space separated and
@@ -162,6 +169,7 @@ class VariableAnalysisSniff implements Sniff
 			T_COMMA,
 			T_SEMICOLON,
 			T_CLOSE_PARENTHESIS,
+			T_FOR,
 		];
 		if (defined('T_FN')) {
 			$types[] = T_FN;
@@ -216,6 +224,7 @@ class VariableAnalysisSniff implements Sniff
 		// easily accessed in other places which aren't passed the object.
 		if ($this->currentFile !== $phpcsFile) {
 			$this->currentFile = $phpcsFile;
+			$this->forLoops = [];
 		}
 
 		// Add the global scope for the current file to our scope indexes.
@@ -227,6 +236,10 @@ class VariableAnalysisSniff implements Sniff
 		// Report variables defined but not used in the current scope as unused
 		// variables if the current token closes scopes.
 		$this->searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr);
+
+		// Scan variables that were postponed because they exist in the increment
+		// expression of a for loop if the current token closes a loop.
+		$this->processClosingForLoopsAt($phpcsFile, $stackPtr);
 
 		// Find and process variables to perform two jobs: to record variable
 		// definition or use, and to report variables as undefined if they are used
@@ -241,6 +254,13 @@ class VariableAnalysisSniff implements Sniff
 		}
 		if (($token['code'] === T_STRING) && ($token['content'] === 'compact')) {
 			$this->processCompact($phpcsFile, $stackPtr);
+			return;
+		}
+
+		// Record for loop boundaries so we can delay scanning the third for loop
+		// expression until after the loop has been scanned.
+		if ($token['code'] === T_FOR) {
+			$this->recordForLoop($phpcsFile, $stackPtr);
 			return;
 		}
 
@@ -266,6 +286,19 @@ class VariableAnalysisSniff implements Sniff
 	}
 
 	/**
+	 * Record the boundaries of a for loop.
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $stackPtr
+	 *
+	 * @return void
+	 */
+	private function recordForLoop($phpcsFile, $stackPtr)
+	{
+		$this->forLoops[$stackPtr] = Helpers::makeForLoopInfo($phpcsFile, $stackPtr);
+	}
+
+	/**
 	 * Find scopes closed by a token and process their variables.
 	 *
 	 * Calls `processScopeClose()` for each closed scope.
@@ -279,9 +312,37 @@ class VariableAnalysisSniff implements Sniff
 	{
 		$scopeIndicesThisCloses = $this->scopeManager->getScopesForScopeEnd($phpcsFile->getFilename(), $stackPtr);
 
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$line = $token['line'];
 		foreach ($scopeIndicesThisCloses as $scopeIndexThisCloses) {
-			Helpers::debug('found closing scope at index', $stackPtr, 'for scopes starting at:', $scopeIndexThisCloses);
+			Helpers::debug('found closing scope at index', $stackPtr, 'line', $line, 'for scopes starting at:', $scopeIndexThisCloses->scopeStartIndex);
 			$this->processScopeClose($phpcsFile, $scopeIndexThisCloses->scopeStartIndex);
+		}
+	}
+
+	/**
+	 * Scan variables that were postponed because they exist in the increment expression of a for loop.
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $stackPtr
+	 *
+	 * @return void
+	 */
+	private function processClosingForLoopsAt($phpcsFile, $stackPtr)
+	{
+		$forLoopsThisCloses = [];
+		foreach ($this->forLoops as $forLoop) {
+			if ($forLoop->blockEnd === $stackPtr) {
+				$forLoopsThisCloses[] = $forLoop;
+			}
+		}
+
+		foreach ($forLoopsThisCloses as $forLoop) {
+			foreach ($forLoop->incrementVariables as $varIndex => $varInfo) {
+				Helpers::debug('processing delayed for loop increment variable at', $varIndex, $varInfo);
+				$this->processVariable($phpcsFile, $varIndex, ['ignore-for-loops' => true]);
+			}
 		}
 	}
 
@@ -362,7 +423,7 @@ class VariableAnalysisSniff implements Sniff
 		Helpers::debug("getOrCreateVariableInfo: starting for '{$varName}'");
 		$scopeInfo = $this->getOrCreateScopeInfo($currScope);
 		if (isset($scopeInfo->variables[$varName])) {
-			Helpers::debug("getOrCreateVariableInfo: found scope for '{$varName}'", $scopeInfo);
+			Helpers::debug("getOrCreateVariableInfo: found variable for '{$varName}'", $scopeInfo->variables[$varName]);
 			return $scopeInfo->variables[$varName];
 		}
 		Helpers::debug("getOrCreateVariableInfo: creating a new variable for '{$varName}' in scope", $scopeInfo);
@@ -566,7 +627,7 @@ class VariableAnalysisSniff implements Sniff
 	protected function isVariableUndefined($varName, $stackPtr, $currScope)
 	{
 		$varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
-		Helpers::debug('isVariableUndefined', $varInfo);
+		Helpers::debug('isVariableUndefined', $varInfo, 'at', $stackPtr);
 		if ($varInfo->ignoreUndefined) {
 			return false;
 		}
@@ -575,6 +636,31 @@ class VariableAnalysisSniff implements Sniff
 		}
 		if (isset($varInfo->firstInitialized) && $varInfo->firstInitialized <= $stackPtr) {
 			return false;
+		}
+		// If we are inside a for loop increment expression, check to see if the
+		// variable was defined inside the for loop.
+		foreach ($this->forLoops as $forLoop) {
+			if ($stackPtr > $forLoop->incrementStart && $stackPtr < $forLoop->incrementEnd) {
+				Helpers::debug('isVariableUndefined looking at increment expression for loop', $forLoop);
+				if (
+					isset($varInfo->firstInitialized)
+					&& $varInfo->firstInitialized > $forLoop->blockStart
+					&& $varInfo->firstInitialized < $forLoop->blockEnd
+				) {
+					return false;
+				}
+			}
+		}
+		// If we are inside a for loop body, check to see if the variable was
+		// defined in that loop's third expression.
+		foreach ($this->forLoops as $forLoop) {
+			if ($stackPtr > $forLoop->blockStart && $stackPtr < $forLoop->blockEnd) {
+				foreach ($forLoop->incrementVariables as $forLoopVarInfo) {
+					if ($varInfo === $forLoopVarInfo) {
+						return false;
+					}
+				}
+			}
 		}
 		return true;
 	}
@@ -1418,12 +1504,17 @@ class VariableAnalysisSniff implements Sniff
 	 * functions to this one, like `processVariableInString`, and
 	 * `processCompact`. They have the same purpose as this function, though.
 	 *
-	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
-	 * @param int  $stackPtr  The position where the token was found.
+	 * If the 'ignore-for-loops' option is true, we will ignore the special
+	 * processing for the increment variables of for loops. This will prevent
+	 * infinite loops.
+	 *
+	 * @param File                           $phpcsFile The PHP_CodeSniffer file where this token was found.
+	 * @param int                            $stackPtr  The position where the token was found.
+	 * @param array<string, bool|string|int> $options   See above.
 	 *
 	 * @return void
 	 */
-	protected function processVariable(File $phpcsFile, $stackPtr)
+	protected function processVariable(File $phpcsFile, $stackPtr, $options = [])
 	{
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[$stackPtr];
@@ -1459,6 +1550,18 @@ class VariableAnalysisSniff implements Sniff
 		//   Declares as a static
 		//   Assignment via foreach (... as ...) { }
 		//   Pass-by-reference to known pass-by-reference function
+
+		// Are we inside the third expression of a for loop? Store such variables
+		// for processing after the loop ends by `processClosingForLoopsAt()`.
+		if (empty($options['ignore-for-loops'])) {
+			$forLoop = Helpers::getForLoopForIncrementVariable($stackPtr, $this->forLoops);
+			if ($forLoop) {
+				Helpers::debug('found variable inside for loop third expression');
+				$varInfo = $this->getOrCreateVariableInfo($varName, $currScope);
+				$forLoop->incrementVariables[$stackPtr] = $varInfo;
+				return;
+			}
+		}
 
 		// Are we a $object->$property type symbolic reference?
 		if ($this->processVariableAsSymbolicObjectProperty($phpcsFile, $stackPtr, $varName, $currScope)) {

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1622,7 +1622,7 @@ class VariableAnalysisSniff implements Sniff
 		if (Helpers::isTokenInsideAssignmentLHS($phpcsFile, $stackPtr)) {
 			Helpers::debug('found assignment');
 			$this->processVariableAsAssignment($phpcsFile, $stackPtr, $varName, $currScope);
-			if (Helpers::isTokenInsideAssignmentRHS($phpcsFile, $stackPtr) || Helpers::isTokenInsideFunctionCall($phpcsFile, $stackPtr)) {
+			if (Helpers::isTokenInsideAssignmentRHS($phpcsFile, $stackPtr) || Helpers::isTokenInsideFunctionCallArgument($phpcsFile, $stackPtr)) {
 				Helpers::debug("found assignment that's also inside an expression");
 				$this->markVariableRead($varName, $stackPtr, $currScope);
 				return;


### PR DESCRIPTION
In most cases, for loops do not require special processing by this sniff because they share the variable scope of their container. However, the third expression of the loop (what I'm calling the "increment expression") is technically not evaluated until _after_ the loop runs at least once. This means that you could define a variable inside the loop that is then used in the increment expression, despite the definition coming lexically after the use.

In this PR, we modify the sniff to set aside variables in the increment expression until after the loop has been parsed. Variables found in this way are then parsed in their own operation (but in their original position).

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/261