### PR TITLE
Add psalm static analysis

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml
 
-  phpstan:
-    name: "PHP: 7.4 | PHPStan"
+  static-analysis:
+    name: "PHP: 7.4 | Static Analysis"
     runs-on: ubuntu-latest
 
     steps:
@@ -90,5 +90,5 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 
-      - name: Run PHPStan
-        run: composer phpstan
+      - name: Run Static Analysis
+        run: composer static-analysis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.5.2" --no-interaction
+        run: composer require php-coveralls/php-coveralls:"^2.5.2" --no-interaction --with-all-dependencies
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -889,7 +889,7 @@ class Helpers
 	 * @param File $phpcsFile
 	 * @param int  $scopeStartIndex
 	 *
-	 * @return int
+	 * @return int|null
 	 */
 	public static function getScopeCloseForScopeOpen(File $phpcsFile, $scopeStartIndex)
 	{

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -889,12 +889,12 @@ class Helpers
 	 * @param File $phpcsFile
 	 * @param int  $scopeStartIndex
 	 *
-	 * @return int|null
+	 * @return int
 	 */
 	public static function getScopeCloseForScopeOpen(File $phpcsFile, $scopeStartIndex)
 	{
 		$tokens = $phpcsFile->getTokens();
-		$scopeCloserIndex = isset($tokens[$scopeStartIndex]['scope_closer']) ? $tokens[$scopeStartIndex]['scope_closer'] : null;
+		$scopeCloserIndex = isset($tokens[$scopeStartIndex]['scope_closer']) ? $tokens[$scopeStartIndex]['scope_closer'] : 0;
 
 		if (self::isArrowFunction($phpcsFile, $scopeStartIndex)) {
 			$arrowFunctionInfo = self::getArrowFunctionOpenClose($phpcsFile, $scopeStartIndex);

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -136,9 +136,9 @@ class Helpers
 	 *
 	 * @return bool
 	 */
-	public static function isTokenInsideFunctionDefinitionArgumentList(File $phpcsFile, $stackPtr)
+	public static function isTokenFunctionParameter(File $phpcsFile, $stackPtr)
 	{
-		return is_int(self::getFunctionIndexForFunctionArgument($phpcsFile, $stackPtr));
+		return is_int(self::getFunctionIndexForFunctionParameter($phpcsFile, $stackPtr));
 	}
 
 	/**
@@ -167,7 +167,7 @@ class Helpers
 	 *
 	 * @return ?int
 	 */
-	public static function getFunctionIndexForFunctionArgument(File $phpcsFile, $stackPtr)
+	public static function getFunctionIndexForFunctionParameter(File $phpcsFile, $stackPtr)
 	{
 		$tokens = $phpcsFile->getTokens();
 		$token = $tokens[$stackPtr];
@@ -437,8 +437,8 @@ class Helpers
 		}
 
 		// If there is no "conditions" array, this is a function definition argument.
-		if (self::isTokenInsideFunctionDefinitionArgumentList($phpcsFile, $stackPtr)) {
-			$functionPtr = self::getFunctionIndexForFunctionArgument($phpcsFile, $stackPtr);
+		if (self::isTokenFunctionParameter($phpcsFile, $stackPtr)) {
+			$functionPtr = self::getFunctionIndexForFunctionParameter($phpcsFile, $stackPtr);
 			if (! is_int($functionPtr)) {
 				throw new \Exception("Function index not found for function argument index {$stackPtr}");
 			}

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -22,7 +22,7 @@ class VariableInfo
 	public $scopeType;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	public $typeHint;
 

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -17,7 +17,7 @@ class VariableInfo
 	/**
 	 * What scope the variable has: local, param, static, global, bound
 	 *
-	 * @var ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE
+	 * @var ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE|null
 	 */
 	public $scopeType;
 

--- a/VariableAnalysis/Lib/VariableInfo.php
+++ b/VariableAnalysis/Lib/VariableInfo.php
@@ -17,7 +17,7 @@ class VariableInfo
 	/**
 	 * What scope the variable has: local, param, static, global, bound
 	 *
-	 * @var string
+	 * @var ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE
 	 */
 	public $scopeType;
 
@@ -89,7 +89,7 @@ class VariableInfo
 	public $isForeachLoopAssociativeValue = false;
 
 	/**
-	 * @var string[]
+	 * @var array<ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE, string>
 	 */
 	public static $scopeTypeDescriptions = [
 		ScopeType::LOCAL  => 'variable',

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -298,9 +298,6 @@ class VariableAnalysisSniff implements Sniff
 	private function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
 	{
 		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
-		if (is_null($scopeEndIndex)) {
-			return;
-		}
 		$filename = $this->getFilename();
 		if (! isset($this->scopeStartEndPairs[$filename])) {
 			$this->scopeStartEndPairs[$filename] = [];

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1950,7 +1950,7 @@ class VariableAnalysisSniff implements Sniff
 				$indexForWarning,
 				'UnusedVariable',
 				[
-					VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType],
+					VariableInfo::$scopeTypeDescriptions[$varInfo->scopeType ?: ScopeType::LOCAL],
 					"\${$varInfo->name}",
 				]
 			);

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -558,7 +558,7 @@ class VariableAnalysisSniff implements Sniff
 	 * Record that a variable has been defined within a scope.
 	 *
 	 * @param string  $varName
-	 * @param string  $scopeType
+	 * @param ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE  $scopeType
 	 * @param ?string $typeHint
 	 * @param int     $stackPtr
 	 * @param int     $currScope

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -557,12 +557,12 @@ class VariableAnalysisSniff implements Sniff
 	/**
 	 * Record that a variable has been defined within a scope.
 	 *
-	 * @param string  $varName
-	 * @param ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE  $scopeType
-	 * @param ?string $typeHint
-	 * @param int     $stackPtr
-	 * @param int     $currScope
-	 * @param ?bool   $permitMatchingRedeclaration
+	 * @param string                                                                                           $varName
+	 * @param ScopeType::PARAM|ScopeType::BOUND|ScopeType::LOCAL|ScopeType::GLOBALSCOPE|ScopeType::STATICSCOPE $scopeType
+	 * @param ?string                                                                                          $typeHint
+	 * @param int                                                                                              $stackPtr
+	 * @param int                                                                                              $currScope
+	 * @param ?bool                                                                                            $permitMatchingRedeclaration
 	 *
 	 * @return void
 	 */

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24 || ^5.0"
+        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24 || 5.0.0-beta1 || ^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "lint": "./vendor/bin/phpcs",
         "fix": "./vendor/bin/phpcbf",
         "phpstan": "./vendor/bin/phpstan analyse",
-        "psalm": "./vendor/bin/psalm --no-cache"
+        "psalm": "./vendor/bin/psalm --no-cache",
+        "static-analysis": "composer phpstan && composer psalm"
     },
     "require" : {
         "php" : ">=5.4.0",

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^1.1 || ^4.24"
+        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24"
+        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24 || ^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^4.24"
+        "vimeo/psalm": "^1.1 || ^4.24"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "test": "./vendor/bin/phpunit --no-coverage",
         "coverage": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs",
-        "phpstan": "./vendor/bin/phpstan analyse"
+        "phpstan": "./vendor/bin/phpstan analyse",
+        "psalm": "./vendor/bin/psalm"
     },
     "require" : {
         "php" : ">=5.4.0",
@@ -51,6 +52,7 @@
         "sirbrillig/phpcs-import-detection": "^1.1",
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "vimeo/psalm": "^4.24"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "coverage": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs",
         "phpstan": "./vendor/bin/phpstan analyse",
-        "psalm": "./vendor/bin/psalm"
+        "psalm": "./vendor/bin/psalm --no-cache"
     },
     "require" : {
         "php" : ">=5.4.0",

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || 5.0.0-beta1 || ^5.0"
+        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "vimeo/psalm": "^0.3 || ^1.1 || ^4.24 || 5.0.0-beta1 || ^5.0"
+        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || 5.0.0-beta1 || ^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "test": "./vendor/bin/phpunit --no-coverage",
         "coverage": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs",
+        "fix": "./vendor/bin/phpcbf",
         "phpstan": "./vendor/bin/phpstan analyse",
         "psalm": "./vendor/bin/psalm --no-cache"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,10 +8,10 @@
     #############################################################################
     -->
 
-    <file>.</file>
+    <file>./VariableAnalysis</file>
+    <file>./Tests</file>
 
     <exclude-pattern>./Tests/VariableAnalysisSniff/fixtures/</exclude-pattern>
-    <exclude-pattern>./vendor/</exclude-pattern>
 
     <!-- Only check PHP files. -->
     <arg name="extensions" value="php"/>

--- a/psalm-autoloader.php
+++ b/psalm-autoloader.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . '/vendor/squizlabs/php_codesniffer/src/Util/Tokens.php';
+require_once __DIR__ . '/vendor/autoload.php';

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="3"
+    resolveFromConfigFile="true"
+    autoloader="psalm-autoloader.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="VariableAnalysis" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+    <extraFiles>
+      <directory name="vendor/squizlabs/php_codesniffer" />
+    </extraFiles>
+</psalm>


### PR DESCRIPTION
This adds [psalm](https://psalm.dev/) static analysis to the codebase. I find that psalm is more precise than phpstan in some ways, although phpstan appears to provide some things that psalm does not. Why not have both?