### PR TITLE
Refactor to move scope management to ScopeManager class

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -889,7 +889,7 @@ class Helpers
 	 * @param File $phpcsFile
 	 * @param int  $scopeStartIndex
 	 *
-	 * @return int|null
+	 * @return int
 	 */
 	public static function getScopeCloseForScopeOpen(File $phpcsFile, $scopeStartIndex)
 	{

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -889,7 +889,7 @@ class Helpers
 	 * @param File $phpcsFile
 	 * @param int  $scopeStartIndex
 	 *
-	 * @return int
+	 * @return int|null
 	 */
 	public static function getScopeCloseForScopeOpen(File $phpcsFile, $scopeStartIndex)
 	{

--- a/VariableAnalysis/Lib/ScopeManager.php
+++ b/VariableAnalysis/Lib/ScopeManager.php
@@ -17,12 +17,12 @@ class ScopeManager {
 	 * An associative array of a list of token index pairs which start and end
 	 * scopes and will be used to check for unused variables.
 	 *
-	 * Each array of scopes is keyed by a string containing the filename (see
-	 * `getFilename`).
+	 * The outer array of scopes is keyed by a string containing the filename.
+	 * The inner array of scopes in keyed by the scope start token index.
 	 *
-	 * @var array<string, ScopeInfo[]>
+	 * @var array<string, array<int, ScopeInfo>>
 	 */
-	private $scopeStartEndPairs = [];
+	private $scopes = [];
 
 	/**
 	 * Add a scope's start and end index to our record for the file.
@@ -30,17 +30,19 @@ class ScopeManager {
 	 * @param File $phpcsFile
 	 * @param int  $scopeStartIndex
 	 *
-	 * @return void
+	 * @return ScopeInfo
 	 */
 	public function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
 	{
 		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
 		$filename = $phpcsFile->getFilename();
-		if (! isset($this->scopeStartEndPairs[$filename])) {
-			$this->scopeStartEndPairs[$filename] = [];
+		if (! isset($this->scopes[$filename])) {
+			$this->scopes[$filename] = [];
 		}
 		Helpers::debug('recording scope for file', $filename, 'start/end', $scopeStartIndex, $scopeEndIndex);
-		$this->scopeStartEndPairs[$filename][] = new ScopeInfo($scopeStartIndex, $scopeEndIndex);
+		$scope = new ScopeInfo($scopeStartIndex, $scopeEndIndex);
+		$this->scopes[$filename][$scopeStartIndex] = $scope;
+		return $scope;
 	}
 
 	/**
@@ -52,9 +54,25 @@ class ScopeManager {
 	 */
 	public function getScopesForFilename($filename)
 	{
-		if (empty($this->scopeStartEndPairs[$filename])) {
+		if (empty($this->scopes[$filename])) {
 			return [];
 		}
-		return $this->scopeStartEndPairs[$filename];
+		return array_values($this->scopes[$filename]);
+	}
+
+	/**
+	 * Return the scope for a scope start index.
+	 *
+	 * @param string  $filename
+	 * @param int  $scopeStartIndex
+	 *
+	 * @return ScopeInfo|null
+	 */
+	public function getScopeForScopeStart($filename, $scopeStartIndex)
+	{
+		if (empty($this->scopes[$filename][$scopeStartIndex])) {
+			return null;
+		}
+		return $this->scopes[$filename][$scopeStartIndex];
 	}
 }

--- a/VariableAnalysis/Lib/ScopeManager.php
+++ b/VariableAnalysis/Lib/ScopeManager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace VariableAnalysis\Lib;
+
+use VariableAnalysis\Lib\ScopeInfo;
+use VariableAnalysis\Lib\ScopeType;
+use VariableAnalysis\Lib\VariableInfo;
+use VariableAnalysis\Lib\Constants;
+use VariableAnalysis\Lib\Helpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ScopeManager {
+
+	/**
+	 * An associative array of a list of token index pairs which start and end
+	 * scopes and will be used to check for unused variables.
+	 *
+	 * Each array of scopes is keyed by a string containing the filename (see
+	 * `getFilename`).
+	 *
+	 * @var array<string, ScopeInfo[]>
+	 */
+	private $scopeStartEndPairs = [];
+
+	/**
+	 * Add a scope's start and end index to our record for the file.
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $scopeStartIndex
+	 *
+	 * @return void
+	 */
+	public function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
+	{
+		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
+		$filename = $phpcsFile->getFilename();
+		if (! isset($this->scopeStartEndPairs[$filename])) {
+			$this->scopeStartEndPairs[$filename] = [];
+		}
+		Helpers::debug('recording scope for file', $filename, 'start/end', $scopeStartIndex, $scopeEndIndex);
+		$this->scopeStartEndPairs[$filename][] = new ScopeInfo($scopeStartIndex, $scopeEndIndex);
+	}
+
+	/**
+	 * Return the scopes for a file.
+	 *
+	 * @param string  $filename
+	 *
+	 * @return ScopeInfo[]
+	 */
+	public function getScopesForFilename($filename)
+	{
+		if (empty($this->scopeStartEndPairs[$filename])) {
+			return [];
+		}
+		return $this->scopeStartEndPairs[$filename];
+	}
+}

--- a/VariableAnalysis/Lib/ScopeManager.php
+++ b/VariableAnalysis/Lib/ScopeManager.php
@@ -3,13 +3,8 @@
 namespace VariableAnalysis\Lib;
 
 use VariableAnalysis\Lib\ScopeInfo;
-use VariableAnalysis\Lib\ScopeType;
-use VariableAnalysis\Lib\VariableInfo;
-use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\Helpers;
-use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 
 class ScopeManager
 {
@@ -32,7 +27,7 @@ class ScopeManager
 	 *
 	 * @return ScopeInfo
 	 */
-	public function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
+	public function recordScopeStartAndEnd(File $phpcsFile, $scopeStartIndex)
 	{
 		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
 		$filename = $phpcsFile->getFilename();

--- a/VariableAnalysis/Lib/ScopeManager.php
+++ b/VariableAnalysis/Lib/ScopeManager.php
@@ -11,8 +11,8 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ScopeManager {
-
+class ScopeManager
+{
 	/**
 	 * An associative array of a list of token index pairs which start and end
 	 * scopes and will be used to check for unused variables.
@@ -48,7 +48,7 @@ class ScopeManager {
 	/**
 	 * Return the scopes for a file.
 	 *
-	 * @param string  $filename
+	 * @param string $filename
 	 *
 	 * @return ScopeInfo[]
 	 */
@@ -63,8 +63,8 @@ class ScopeManager {
 	/**
 	 * Return the scope for a scope start index.
 	 *
-	 * @param string  $filename
-	 * @param int  $scopeStartIndex
+	 * @param string $filename
+	 * @param int    $scopeStartIndex
 	 *
 	 * @return ScopeInfo|null
 	 */
@@ -79,8 +79,8 @@ class ScopeManager {
 	/**
 	 * Find scopes closed by a scope close index.
 	 *
-	 * @param string  $filename
-	 * @param int  $scopeEndIndex
+	 * @param string $filename
+	 * @param int    $scopeEndIndex
 	 *
 	 * @return ScopeInfo[]
 	 */
@@ -110,5 +110,4 @@ class ScopeManager {
 		);
 		return $scopeIndicesThisCloses;
 	}
-
 }

--- a/VariableAnalysis/Lib/ScopeManager.php
+++ b/VariableAnalysis/Lib/ScopeManager.php
@@ -75,4 +75,40 @@ class ScopeManager {
 		}
 		return $this->scopes[$filename][$scopeStartIndex];
 	}
+
+	/**
+	 * Find scopes closed by a scope close index.
+	 *
+	 * @param string  $filename
+	 * @param int  $scopeEndIndex
+	 *
+	 * @return ScopeInfo[]
+	 */
+	public function getScopesForScopeEnd($filename, $scopeEndIndex)
+	{
+		$scopePairsForFile = $this->getScopesForFilename($filename);
+		$scopeIndicesThisCloses = array_reduce(
+			$scopePairsForFile,
+			/**
+			 * @param ScopeInfo[] $found
+			 * @param ScopeInfo   $scope
+			 *
+			 * @return ScopeInfo[]
+			 */
+			function ($found, $scope) use ($scopeEndIndex) {
+				if (! is_int($scope->scopeEndIndex)) {
+					Helpers::debug('No scope closer found for scope start', $scope->scopeStartIndex);
+					return $found;
+				}
+
+				if ($scopeEndIndex === $scope->scopeEndIndex) {
+					$found[] = $scope;
+				}
+				return $found;
+			},
+			[]
+		);
+		return $scopeIndicesThisCloses;
+	}
+
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -219,7 +219,8 @@ class VariableAnalysisSniff implements Sniff
 		}
 
 		// Add the global scope for the current file to our scope indexes.
-		if (empty($this->scopeManager->getScopesForFilename($phpcsFile->getFilename()))) {
+		$scopesForFilename = $this->scopeManager->getScopesForFilename($phpcsFile->getFilename());
+		if (empty($scopesForFilename)) {
 			$this->scopeManager->recordScopeStartAndEnd($phpcsFile, 0);
 		}
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -286,9 +286,6 @@ class VariableAnalysisSniff implements Sniff
 	private function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
 	{
 		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
-		if (is_null($scopeEndIndex)) {
-			return;
-		}
 		$filename = $this->getFilename();
 		if (! isset($this->scopeStartEndPairs[$filename])) {
 			$this->scopeStartEndPairs[$filename] = [];

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -38,9 +38,6 @@ class VariableAnalysisSniff implements Sniff
 	 * Each array of scopes is keyed by a string containing the filename (see
 	 * `getFilename`).
 	 *
-	 * Unlike the `ScopeInfo` objects stored in `$this->scopes`, these objects do
-	 * not track variables themselves, only the position of the scope boundaries.
-	 *
 	 * @var array<string, ScopeInfo[]>
 	 */
 	private $scopeStartEndPairs = [];
@@ -246,8 +243,13 @@ class VariableAnalysisSniff implements Sniff
 			$this->recordScopeStartAndEnd($phpcsFile, 0);
 		}
 
+<<<<<<< HEAD
 		// Report variables defined but not used in the current scope as unused
 		// variables if the current token closes scopes.
+=======
+		// Report variables defined in the current scope but not used as unused
+		// variables if the current token closes a scope.
+>>>>>>> 766adf5 (Fix some minor type errors and improve code comments)
 		$this->searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr);
 
 		// Find and process variables to perform two jobs: to record variable
@@ -298,6 +300,9 @@ class VariableAnalysisSniff implements Sniff
 	private function recordScopeStartAndEnd($phpcsFile, $scopeStartIndex)
 	{
 		$scopeEndIndex = Helpers::getScopeCloseForScopeOpen($phpcsFile, $scopeStartIndex);
+		if (is_null($scopeEndIndex)) {
+			return;
+		}
 		$filename = $this->getFilename();
 		if (! isset($this->scopeStartEndPairs[$filename])) {
 			$this->scopeStartEndPairs[$filename] = [];
@@ -348,7 +353,13 @@ class VariableAnalysisSniff implements Sniff
 	/**
 	 * Find scopes closed by a token and process their variables.
 	 *
+<<<<<<< HEAD
 	 * Calls `processScopeClose()` for each closed scope.
+=======
+	 * Calls `processScopeClose()` for each closed scope. Requires that
+	 * `scopeEndIndexCache` has been populated for the current file by
+	 * `recordScopeStartAndEnd()`.
+>>>>>>> 766adf5 (Fix some minor type errors and improve code comments)
 	 *
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -234,13 +234,8 @@ class VariableAnalysisSniff implements Sniff
 			$this->recordScopeStartAndEnd($phpcsFile, 0);
 		}
 
-<<<<<<< HEAD
 		// Report variables defined but not used in the current scope as unused
 		// variables if the current token closes scopes.
-=======
-		// Report variables defined in the current scope but not used as unused
-		// variables if the current token closes a scope.
->>>>>>> 766adf5 (Fix some minor type errors and improve code comments)
 		$this->searchForAndProcessClosingScopesAt($phpcsFile, $stackPtr);
 
 		// Find and process variables to perform two jobs: to record variable
@@ -365,13 +360,7 @@ class VariableAnalysisSniff implements Sniff
 	/**
 	 * Find scopes closed by a token and process their variables.
 	 *
-<<<<<<< HEAD
 	 * Calls `processScopeClose()` for each closed scope.
-=======
-	 * Calls `processScopeClose()` for each closed scope. Requires that
-	 * `scopeStartEndPairs` has been populated for the current file by
-	 * `recordScopeStartAndEnd()`.
->>>>>>> 766adf5 (Fix some minor type errors and improve code comments)
 	 *
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr


### PR DESCRIPTION
There are three ways that scope is tracked in the sniff:

1. The `scopeEndIndexCache` property.
2. The `scopes` property.
3. The `scopeStartEndPairs` property.

Each of these properties was added to serve a different, but related, purpose. In this PR we modify the sniff to unify the three arrays and move them to a stand-alone class called `ScopeManager`.