### PR TITLE
Support constructor promotion

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -187,6 +187,11 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ClassWithMembersFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+			'allowUnusedParametersBeforeUsed',
+			'false'
+		);
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -202,6 +202,8 @@ class VariableAnalysisTest extends BaseTestCase
 			18,
 			19,
 			66,
+			115,
+			116,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -112,6 +112,8 @@ class ClassWithAssignedMembers {
 class ClassWithConstructorPromotion {
   public function __construct(
         public string $name = 'Brent',
+        $unused, // Unused variable $unused
+        string $unused2, // Unused variable $unused2
         public string $role,
         private string $role2,
         protected string $role3,

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -108,3 +108,16 @@ class ClassWithAssignedMembers {
         }
     }
 }
+
+class ClassWithConstructorPromotion {
+  public function __construct(
+        public string $name = 'Brent',
+        public string $role,
+        private string $role2,
+        protected string $role3,
+        public $nickname,
+        private $nickname2,
+        protected $nickname3
+  ) {
+  }
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1278,4 +1278,43 @@ class Helpers
 		}
 		return null;
 	}
+
+
+	/**
+	 * Return true if the token looks like constructor promotion.
+	 *
+	 * Call on a parameter variable token only.
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $stackPtr
+	 *
+	 * @return bool
+	 */
+	public static function isConstructorPromotion(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+		if (! is_int($prev)) {
+			return false;
+		}
+
+		// If the previous token is a visibility keyword, this is constructor promotion.
+		$prevToken = $tokens[$prev];
+		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
+			return true;
+		}
+
+		// If the previous token is not a visibility keyword, but the one before it
+		// is, the previous token was probably a typehint and this is constructor
+		// promotion.
+		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+		if (! is_int($prev)) {
+			return false;
+		}
+
+		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1291,14 +1291,19 @@ class Helpers
 	 */
 	public static function isConstructorPromotion(File $phpcsFile, $stackPtr)
 	{
-		$tokens = $phpcsFile->getTokens();
-
-		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-		if (! is_int($prev)) {
+		$functionIndex = self::getFunctionIndexForFunctionParameter($phpcsFile, $stackPtr);
+		if (! $functionIndex) {
 			return false;
 		}
 
-		// If the previous token is a visibility keyword, this is constructor promotion.
+		$tokens = $phpcsFile->getTokens();
+
+		// If the previous token is a visibility keyword, this is constructor
+		// promotion. eg: `public $foobar`.
+		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), $functionIndex, true);
+		if (! is_int($prev)) {
+			return false;
+		}
 		$prevToken = $tokens[$prev];
 		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
 			return true;
@@ -1306,15 +1311,16 @@ class Helpers
 
 		// If the previous token is not a visibility keyword, but the one before it
 		// is, the previous token was probably a typehint and this is constructor
-		// promotion.
-		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+		// promotion. eg: `public boolean $foobar`.
+		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), $functionIndex, true);
 		if (! is_int($prev)) {
 			return false;
 		}
-
+		$prevToken = $tokens[$prev];
 		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
 			return true;
 		}
+
 		return false;
 	}
 }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1279,7 +1279,6 @@ class Helpers
 		return null;
 	}
 
-
 	/**
 	 * Return true if the token looks like constructor promotion.
 	 *
@@ -1290,7 +1289,8 @@ class Helpers
 	 *
 	 * @return bool
 	 */
-	public static function isConstructorPromotion(File $phpcsFile, $stackPtr) {
+	public static function isConstructorPromotion(File $phpcsFile, $stackPtr)
+	{
 		$tokens = $phpcsFile->getTokens();
 
 		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -761,6 +761,12 @@ class VariableAnalysisSniff implements Sniff
 			Helpers::debug('processVariableAsFunctionParameter optional with default');
 			$this->markVariableAssignment($varName, $stackPtr, $functionPtr);
 		}
+
+		// Are we using constructor promotion? If so, that counts as both definition and use.
+		if (Helpers::isConstructorPromotion($phpcsFile, $stackPtr)) {
+			Helpers::debug('processVariableAsFunctionParameter constructor promotion');
+			$this->markVariableRead($varName, $stackPtr, $outerScope);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Function parameters defined using PHP 8 [constructor promotion](https://stitcher.io/blog/constructor-promotion-in-php-8) should count as both a variable definition AND a variable use because there's an implied assignment of such variables to class properties of the same name. This PR adds support for them.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/227