### PR TITLE
Improve static declaration checks

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -300,20 +300,25 @@ class VariableAnalysisTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
-			8,
-			20,
-			32,
-			33,
-			34,
-			36,
-			37,
-			39,
-			40,
+			10,
+			11,
+			12,
+			13,
+			14,
+			16,
+			29,
+			41,
+			42,
+			43,
 			46,
-			59,
-			60,
-			64,
+			52,
+			56,
+			57,
+			63,
+			76,
+			77,
 			81,
+			98,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -330,18 +335,23 @@ class VariableAnalysisTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
-			8,
-			20,
-			32,
-			33,
-			34,
-			36,
-			37,
-			39,
-			40,
+			10,
+			11,
+			12,
+			13,
+			14,
+			16,
+			29,
+			41,
+			42,
+			43,
 			46,
-			64,
+			52,
+			56,
+			57,
+			63,
 			81,
+			98,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -358,19 +368,24 @@ class VariableAnalysisTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
-			8,
-			20,
-			32,
-			33,
-			34,
-			36,
-			37,
-			39,
-			40,
+			10,
+			11,
+			12,
+			13,
+			14,
+			16,
+			29,
+			41,
+			42,
+			43,
 			46,
-			59,
-			60,
-			81,
+			52,
+			56,
+			57,
+			63,
+			76,
+			77,
+			98,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -45,8 +45,8 @@ class ClassWithoutMembers {
 
 class ClassWithMembers {
     public $member_var;
-    private $private_member_var;
-    protected $protected_member_var;
+    private ?string $private_member_var;
+    protected string $protected_member_var;
     static $static_member_var;
 
     function method_with_member_var() {
@@ -121,5 +121,20 @@ class ClassWithConstructorPromotion {
         private $nickname2,
         protected $nickname3
   ) {
+  }
+}
+
+class ClassWithStaticProperties {
+  static $static_simple;
+  public static $static_with_visibility;
+  public static $static_with_visibility_unused;
+  public static int $static_with_visibility_and_type;
+  public static ?int $static_with_visibility_and_nullable_type;
+
+  public function use_vars() {
+    echo self::$static_simple;
+    echo self::$static_with_visibility;
+    echo self::$static_with_visibility_and_type;
+    echo self::$static_with_visibility_and_nullable_type;
   }
 }

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -141,4 +141,22 @@ class ClassWithStaticProperties {
   public static function getIntOrNull($value) {
     return is_int($value) ? $value : null;
   }
+
+  static function getIntOrNull2($value) {
+    return is_int($value) ? $value : null;
+  }
+}
+
+abstract class AbstractClassWithStaticProperties {
+  static $static_simple;
+  public static $static_with_visibility;
+  public static $static_with_visibility_unused;
+  public static int $static_with_visibility_and_type;
+  public static ?int $static_with_visibility_and_nullable_type;
+
+  public function use_vars();
+
+  public static function getIntOrNull($value);
+
+  static function getIntOrNull2($value);
 }

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -137,4 +137,8 @@ class ClassWithStaticProperties {
     echo self::$static_with_visibility_and_type;
     echo self::$static_with_visibility_and_nullable_type;
   }
+
+  public static function getIntOrNull($value) {
+    return is_int($value) ? $value : null;
+  }
 }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
@@ -5,7 +5,16 @@ function /*comment*/ &function_with_return_by_reference_and_param($param) {
 }
 
 function function_with_static_var() {
-    static $static1, $static_num = 12, $static_neg_num = -1.5, $static_string = 'abc', $static_string2 = "def", $static_define = MYDEFINE, $static_constant = MyClass::CONSTANT, $static2, $static_new = new Foobar();
+  static $static1,
+    $static_num = 12,
+    $static_neg_num = -1.5, // Unused variable $static_neg_num
+    $static_string = 'abc', // Unused variable $static_string
+    $static_string2 = "def", // Unused variable $static_string2
+    $static_define = MYDEFINE, // Unused variable $static_define
+    $static_constant = MyClass::CONSTANT, // Unused variable $static_constant
+    $static2,
+    $static_new_unused = new Foobar(), // Unused variable $static_new_unused
+    $static_new = new Foobar();
     static $static_heredoc = <<<END_OF_HEREDOC
 this is an ugly but valid way to continue after a heredoc
 END_OF_HEREDOC
@@ -17,7 +26,7 @@ END_OF_NOWDOC
     echo $static1;
     echo $static_num;
     echo $static2;
-    echo $var;
+    echo $var; // Undefined variable $var
     echo $static_heredoc;
     echo $static3;
     echo $static_nowdoc;
@@ -29,21 +38,29 @@ function function_with_pass_by_reference_param(&$param) {
 }
 
 function function_with_pass_by_reference_calls() {
-    echo $matches;
-    echo $needle;
-    echo $haystack;
+    echo $matches; // Undefined variable $matches
+    echo $needle; // Undefined variable $needle
+    echo $haystack; // Undefined variable $haystack
     preg_match('/(abc)/', 'defabcghi', /* comment */ $matches);
-    preg_match($needle,   'defabcghi', $matches);
-    preg_match('/(abc)/', $haystack,   $matches);
+    preg_match(
+      $needle, // Undefined variable $needle
+      'defabcghi',
+      $matches
+    );
+    preg_match(
+      '/(abc)/',
+      $haystack, // Undefined variable $haystack
+      $matches
+    );
     echo $matches;
-    echo $needle;
-    echo $haystack;
+    echo $needle; // Undefined variable $needle
+    echo $haystack; // Undefined variable $haystack
     $stmt = 'whatever';
     $var1 = 'one';
     $var2 = 'two';
     echo $var1;
     echo $var2;
-    echo $var3;
+    echo $var3; // Undefined variable $var3
     maxdb_stmt_bind_result /*comment*/ ($stmt, $var1, $var2, $var3);
     echo $var1;
     echo $var2;
@@ -56,12 +73,12 @@ function function_with_pass_by_ref_assign_only_arg(&  /*comment*/  $return_value
 
 function function_with_ignored_reference_call() {
     $foo = 'bar';
-    my_reference_function($foo, $baz, $bip);
-    another_reference_function($foo, $foo2, $foo3);
+    my_reference_function($foo, $baz, $bip); // Undefined variable $bar, Undefined variable $bip
+    another_reference_function($foo, $foo2, $foo3); // Undefined variable $foo2, Undefined variable $foo3
 }
 
 function function_with_wordpress_reference_calls() {
-    wp_parse_str('foo=bar', $vars);
+    wp_parse_str('foo=bar', $vars); // Undefined variable $vars
 }
 
 function function_with_array_walk($userNameParts) {
@@ -78,7 +95,7 @@ function function_with_foreach_with_reference($derivatives, $base_plugin_definit
   foreach ($derivatives as &$entry) {
     $entry .= $base_plugin_definition;
   }
-  foreach ($derivatives as &$unused) { // unused variable
+  foreach ($derivatives as &$unused) { // Unused variable $unused
     $base_plugin_definition .= '1';
   }
   return $derivatives;

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
@@ -5,7 +5,7 @@ function /*comment*/ &function_with_return_by_reference_and_param($param) {
 }
 
 function function_with_static_var() {
-    static $static1, $static_num = 12, $static_neg_num = -1.5, $static_string = 'abc', $static_string2 = "def", $static_define = MYDEFINE, $static_constant = MyClass::CONSTANT, $static2;
+    static $static1, $static_num = 12, $static_neg_num = -1.5, $static_string = 'abc', $static_string2 = "def", $static_define = MYDEFINE, $static_constant = MyClass::CONSTANT, $static2, $static_new = new Foobar();
     static $static_heredoc = <<<END_OF_HEREDOC
 this is an ugly but valid way to continue after a heredoc
 END_OF_HEREDOC
@@ -21,7 +21,7 @@ END_OF_NOWDOC
     echo $static_heredoc;
     echo $static3;
     echo $static_nowdoc;
-    echo $static4;
+    echo $static4 . $static_new;
 }
 
 function function_with_pass_by_reference_param(&$param) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -159,11 +159,13 @@ class Helpers
 	}
 
 	/**
-	 * Find the index of the function keyword for a token in a function definition's arguments
+	 * Find the index of the function keyword for a token in a function
+	 * definition's parameters.
 	 *
 	 * Does not work for tokens inside the "use".
 	 *
-	 * Will also work for the parenthesis that make up the function definition's arguments list.
+	 * Will also work for the parenthesis that make up the function definition's
+	 * parameters list.
 	 *
 	 * For arguments inside a function call, rather than a definition, use
 	 * `getFunctionIndexForFunctionCallArgument`.
@@ -256,6 +258,10 @@ class Helpers
 	}
 
 	/**
+	 * Return the index of a function's name token from inside the function.
+	 *
+	 * $stackPtr must be inside the function body or parameters for this to work.
+	 *
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr
 	 *

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1318,7 +1318,6 @@ class VariableAnalysisSniff implements Sniff
 			T_COLON,
 			T_COMMA,
 			T_DOUBLE_ARROW,
-			T_MATCH_ARROW,
 		];
 		$staticPtr = $phpcsFile->findStartOfStatement($stackPtr - 1, $notEndOfStatementTokens);
 		if (! is_int($staticPtr) || $tokens[$staticPtr]['code'] !== T_STATIC) {


### PR DESCRIPTION
The code used to look for `static $foobar;` variables inside a function is missing for some types of legal assignments. This PR adjusts the sniff to be more liberal in what it allows for a static variable declaration.

It also makes the docs more clear that the sniff ignores static class properties.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/253
Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/158