### PR TITLE
Handle inline if list destructure

### DIFF
--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -100,6 +100,8 @@ class IfConditionTest extends BaseTestCase
 			136,
 			152,
 			154,
+			165,
+			175,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -132,6 +134,8 @@ class IfConditionTest extends BaseTestCase
 			136,
 			152,
 			154,
+			165,
+			175,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForeachFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForeachFixture.php
@@ -82,3 +82,19 @@ function doSomethingLoopy($receipts) {
         }
     }
 }
+
+function foreachWithListDestructure($lines) {
+  $passByRefFunctions = [];
+  foreach ($lines as $line) {
+    list ($function, $args) = explode(':', $line);
+    $passByRefFunctions[$function] = explode(',', $args);
+  }
+}
+
+function foreachWithShortListDestructure($lines) {
+  $passByRefFunctions = [];
+  foreach ($lines as $line) {
+    [$function, $args] = explode(':', $line);
+    $passByRefFunctions[$function] = explode(',', $args);
+  }
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithInlineIfConditionFixture.php
@@ -154,3 +154,23 @@ function definedInsideElseIfBlockUndefinedInsideElseBlockDifferentName($first) {
     echo $third; // undefined variable $third
   echo $words;
 }
+
+function inlineIfWithListDestructure() {
+  if ( true )
+    list( $a ) = [ 'hi' ];
+
+  echo $a;
+
+  if ( true )
+    list( $b ) = [ 'hi' ]; // Unused variable $b
+}
+
+function inlineIfWithShortListDestructure() {
+  if ( true )
+    [ $a ] = [ 'hi' ];
+
+  echo $a;
+
+  if ( true )
+    [ $b ] = [ 'hi' ]; // Unused variable $b
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -44,7 +44,7 @@ class Helpers
 	public static function findContainingOpeningSquareBracket(File $phpcsFile, $stackPtr)
 	{
 		$previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $stackPtr);
-		return self::getIntOrNull($phpcsFile->findPrevious([T_OPEN_SHORT_ARRAY], $stackPtr - 1, $previousStatementPtr));
+		return self::getIntOrNull($phpcsFile->findPrevious([T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET], $stackPtr - 1, $previousStatementPtr));
 	}
 
 	/**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -666,6 +666,22 @@ class Helpers
 		$tokens = $phpcsFile->getTokens();
 		self::debug('getListAssignments', $listOpenerIndex, $tokens[$listOpenerIndex]);
 
+		// If the list opener token is preceeded by a variable or a bracket (a
+		// multidimensional array), this is an array access and not a list
+		// assignment.
+		$previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $listOpenerIndex);
+		$previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $listOpenerIndex - 1, $previousStatementPtr, true);
+		$arrayAccessEvidence = [
+			T_VARIABLE,
+			T_CLOSE_SQUARE_BRACKET,
+		];
+		if (
+			isset($tokens[$previousTokenPtr])
+			&& in_array($tokens[$previousTokenPtr]['code'], $arrayAccessEvidence, true)
+		) {
+			return null;
+		}
+
 		// First find the end of the list
 		$closePtr = null;
 		if (isset($tokens[$listOpenerIndex]['parenthesis_closer'])) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -654,7 +654,70 @@ class Helpers
 	}
 
 	/**
-	 * Return a list of indices for variables assigned within a list assignment
+	 * Determine if a token is a list opener for list assignment/destructuring.
+	 *
+	 * The index provided can be either the opening square brace of a short list
+	 * assignment like the first character of `[$a] = $b;` or the `list` token of
+	 * an expression like `list($a) = $b;` or the opening parenthesis of that
+	 * expression.
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $listOpenerIndex
+	 *
+	 * @return bool
+	 */
+	private static function isListAssignment(File $phpcsFile, $listOpenerIndex)
+	{
+		$tokens = $phpcsFile->getTokens();
+		// Match `[$a] = $b;` except for when the previous token is a parenthesis.
+		if ($tokens[$listOpenerIndex]['code'] === T_OPEN_SHORT_ARRAY) {
+			return true;
+		}
+		// Match `list($a) = $b;`
+		if ($tokens[$listOpenerIndex]['code'] === T_LIST) {
+			return true;
+		}
+
+		// If $listOpenerIndex is the open parenthesis of `list($a) = $b;`, then
+		// match that too.
+		if ($tokens[$listOpenerIndex]['code'] === T_OPEN_PARENTHESIS) {
+			$previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $listOpenerIndex - 1, null, true);
+			if (
+				isset($tokens[$previousTokenPtr])
+				&& $tokens[$previousTokenPtr]['code'] === T_LIST
+			) {
+				return true;
+			}
+			return true;
+		}
+
+		// If the list opener token is a square bracket that is preceeded by a
+		// close parenthesis that has an owner which is a scope opener, then this
+		// is a list assignment and not an array access.
+		//
+		// Match `if (true) [$a] = $b;`
+		if ($tokens[$listOpenerIndex]['code'] === T_OPEN_SQUARE_BRACKET) {
+			$previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $listOpenerIndex - 1, null, true);
+			if (
+				isset($tokens[$previousTokenPtr])
+				&& $tokens[$previousTokenPtr]['code'] === T_CLOSE_PARENTHESIS
+				&& isset($tokens[$previousTokenPtr]['parenthesis_owner'])
+				&& isset(Tokens::$scopeOpeners[$tokens[$tokens[$previousTokenPtr]['parenthesis_owner']]['code']])
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return a list of indices for variables assigned within a list assignment.
+	 *
+	 * The index provided can be either the opening square brace of a short list
+	 * assignment like the first character of `[$a] = $b;` or the `list` token of
+	 * an expression like `list($a) = $b;` or the opening parenthesis of that
+	 * expression.
 	 *
 	 * @param File $phpcsFile
 	 * @param int  $listOpenerIndex
@@ -665,22 +728,6 @@ class Helpers
 	{
 		$tokens = $phpcsFile->getTokens();
 		self::debug('getListAssignments', $listOpenerIndex, $tokens[$listOpenerIndex]);
-
-		// If the list opener token is preceeded by a variable or a bracket (a
-		// multidimensional array), this is an array access and not a list
-		// assignment.
-		$previousStatementPtr = self::getPreviousStatementPtr($phpcsFile, $listOpenerIndex);
-		$previousTokenPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $listOpenerIndex - 1, $previousStatementPtr, true);
-		$arrayAccessEvidence = [
-			T_VARIABLE,
-			T_CLOSE_SQUARE_BRACKET,
-		];
-		if (
-			isset($tokens[$previousTokenPtr])
-			&& in_array($tokens[$previousTokenPtr]['code'], $arrayAccessEvidence, true)
-		) {
-			return null;
-		}
 
 		// First find the end of the list
 		$closePtr = null;
@@ -733,6 +780,10 @@ class Helpers
 				$variablePtrs[] = $variablePtr;
 			}
 			++$currentPtr;
+		}
+
+		if (! self::isListAssignment($phpcsFile, $listOpenerIndex)) {
+			return null;
 		}
 
 		return $variablePtrs;


### PR DESCRIPTION
PHPCS [has a bug](https://github.com/squizlabs/PHP_CodeSniffer/pull/3632) where it incorrectly tokenizes the brackets around a list destructure inside an inline if statement. In this diff, we widen the conditions we consider a list opener to compensate.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/263