### PR TITLE
Remove php_errormsg from superglobals list

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithGlobalVarFixture.php
@@ -67,7 +67,6 @@ function function_with_reserved_variables() {
   return [
     $response,
     $response_headers,
-    $php_errormsg,
     $HTTP_RAW_POST_DATA,
   ];
 }

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -972,7 +972,6 @@ class VariableAnalysisSniff implements Sniff
 			'_ENV',
 			'argv',
 			'argc',
-			'php_errormsg',
 			'http_response_header',
 			'HTTP_RAW_POST_DATA',
 		];


### PR DESCRIPTION
> Also note that $php_errormsg is not a superglobal. It is only available within the scope in which the error occurred and only if the track_errors configuration option is turned on (it defaults to off).

This PR removes `$php_errormsg` from the list of allowed superglobals.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/209