### PR TITLE
Ignore unused parameters when function in abstract class is empty

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -209,6 +209,7 @@ class VariableAnalysisTest extends BaseTestCase
 			66,
 			115,
 			116,
+			174,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -154,9 +154,24 @@ abstract class AbstractClassWithStaticProperties {
   public static int $static_with_visibility_and_type;
   public static ?int $static_with_visibility_and_nullable_type;
 
-  public function use_vars();
+  abstract public function use_vars();
 
-  public static function getIntOrNull($value);
+  abstract public static function getIntOrNull($value);
 
-  static function getIntOrNull2($value);
+  abstract static function getIntOrNull2($value);
+}
+
+abstract class AbstractClassWithEmptyMethodBodies {
+  abstract public function bar($param);
+
+  public function baz($param) {
+  }
+
+  public function baz2($param) {
+    return;
+  }
+
+  public function baz3($param) { // Unused variable $param
+    return 'foobar';
+  }
 }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1407,7 +1407,8 @@ class Helpers
 	 *
 	 * @return bool
 	 */
-	public static function isInAbstractClass(File $phpcsFile, $stackPtr) {
+	public static function isInAbstractClass(File $phpcsFile, $stackPtr)
+	{
 		$classIndex = $phpcsFile->getCondition($stackPtr, T_CLASS);
 		if (! is_int($classIndex)) {
 			return false;
@@ -1420,11 +1421,12 @@ class Helpers
 	 * Return true if the function body is empty or contains only `return;`
 	 *
 	 * @param File $phpcsFile
-	 * @param int  $stackPtr The index of the function keyword.
+	 * @param int  $stackPtr  The index of the function keyword.
 	 *
 	 * @return bool
 	 */
-	public static function isFunctionBodyEmpty(File $phpcsFile, $stackPtr) {
+	public static function isFunctionBodyEmpty(File $phpcsFile, $stackPtr)
+	{
 		$tokens = $phpcsFile->getTokens();
 		if ($tokens[$stackPtr]['code'] !== T_FUNCTION) {
 			return false;
@@ -1440,7 +1442,7 @@ class Helpers
 				T_CLOSE_CURLY_BRACKET,
 			]
 		);
-		for($i = $functionScopeStart; $i < $functionScopeEnd; $i++) {
+		for ($i = $functionScopeStart; $i < $functionScopeEnd; $i++) {
 			if (! in_array($tokens[$i]['code'], $tokensToIgnore, true)) {
 				return false;
 			}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1949,6 +1949,24 @@ class VariableAnalysisSniff implements Sniff
 		if ($scopeInfo->scopeStartIndex === 0 && $this->allowUnusedVariablesInFileScope) {
 			return;
 		}
+		if (
+			! empty($varInfo->firstDeclared)
+			&& $varInfo->scopeType === ScopeType::PARAM
+			&& Helpers::isInAbstractClass(
+				$phpcsFile,
+				Helpers::getFunctionIndexForFunctionParameter($phpcsFile, $varInfo->firstDeclared) ?: 0
+			)
+			&& Helpers::isFunctionBodyEmpty(
+				$phpcsFile,
+				Helpers::getFunctionIndexForFunctionParameter($phpcsFile, $varInfo->firstDeclared) ?: 0
+			)
+		) {
+			// Allow non-abstract methods inside an abstract class to have unused
+			// parameters if the method body does nothing. Such methods are
+			// effectively optional abstract methods so their unused parameters
+			// should be ignored as we do with abstract method parameters.
+			return;
+		}
 
 		$this->warnAboutUnusedVariable($phpcsFile, $varInfo);
 	}


### PR DESCRIPTION
This allows non-abstract methods inside an abstract class to have unused parameters if the method body does nothing. Such methods are effectively optional abstract methods so their unused parameters should be ignored as we do with abstract method parameters.


Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/133