### PR TITLE
Ignore function call arguments on static declarations processing (#272)

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -175,3 +175,11 @@ abstract class AbstractClassWithEmptyMethodBodies {
     return 'foobar';
   }
 }
+
+class ClassWithStaticCreateMethod {
+
+  public static function createStatic($value) {
+    return new static($value);
+  }
+
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
@@ -94,3 +94,10 @@ function function_with_fully_qualified_type_argument_in_closure($items, $item_id
         return $line_item->item_id === $item_id;
     });
 }
+
+function function_with_static_closure() {
+    $params = array();
+    array_map(static function ($inner_param) {
+        echo $inner_param;
+    }, $params);
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1333,6 +1333,12 @@ class VariableAnalysisSniff implements Sniff
 			return false;
 		}
 
+		// Is the token inside a function call? If so, this is not a static
+		// declaration.
+		if (Helpers::isTokenInsideFunctionCallArgument($phpcsFile, $stackPtr)) {
+			return false;
+		}
+
 		// Is the keyword a late static binding? If so, this isn't the static
 		// keyword we're looking for, but since static:: isn't allowed in a
 		// compile-time constant, we also know we can't be part of a static


### PR DESCRIPTION
Provides a fix for #272, adding the following:
- Add check if static declaration is called from within a function call, skipping it if this is the case.
- Add a test to check for static initializer methods, mostly calling the `__construct()`
- Add a test for static closure usage.

This fix doesn't feel like a 100% fix, as the main issue seems to be that the static declaration check sometimes picks up static definitions outside of it's prospected scope. This mostly shows up with static function calls.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/272