### PR TITLE
Fix scanning for static variables near start of file

### DIFF
--- a/Tests/VariableAnalysisSniff/GlobalScopeTest.php
+++ b/Tests/VariableAnalysisSniff/GlobalScopeTest.php
@@ -18,10 +18,11 @@ class GlobalScopeTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
-			4,
-			7,
-			10,
-			13,
+			3,
+			5,
+			8,
+			11,
+			14,
 		];
 		$this->assertSame($expectedErrors, $lines);
 	}
@@ -38,9 +39,10 @@ class GlobalScopeTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
-			4,
-			10,
-			13,
+			3,
+			5,
+			11,
+			14,
 		];
 		$this->assertSame($expectedErrors, $lines);
 	}
@@ -57,8 +59,9 @@ class GlobalScopeTest extends BaseTestCase
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
-			7,
-			10,
+			3,
+			8,
+			11,
 		];
 		$this->assertSame($expectedErrors, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/GlobalScopeFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/GlobalScopeFixture.php
@@ -1,5 +1,6 @@
 <?php
 
+$post = $data['post']; // Undefined variable $data, unused variable $post
 $name = 'friend';
 $place = 'faerie'; // unused variable $place
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1316,8 +1316,7 @@ class VariableAnalysisSniff implements Sniff
 		$startOfStatement = $phpcsFile->findPrevious([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $stackPtr - 1, null, false, null, true);
 		$staticPtr = $phpcsFile->findPrevious([T_STATIC], $stackPtr - 1, null, false, null, true);
 		if (! is_int($startOfStatement)) {
-			$line = $tokens[$stackPtr]['line'];
-			throw new \Exception("Could not find start of statement on line {$line}");
+			$startOfStatement = 1;
 		}
 		if (! is_int($staticPtr)) {
 			return false;


### PR DESCRIPTION
At the start of a file, there is no previous statement, and the code which scans for static variables inside a function needs to know the position of the previous statement to determine how far back to scan. Because of the way this scan was implemented, it would throw an exception if performed at the start of a file.

This PR provides a fallback instead so that if we are at the start of a file, the scan will treat the start of the file as the previous statement position.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/271