### PR TITLE
Place static arrow function body outside of scope on static declaration check (#275)

### DIFF
--- a/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
+++ b/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
@@ -29,6 +29,7 @@ class ArrowFunctionTest extends BaseTestCase
 			61,
 			67,
 			71,
+			87,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -58,6 +59,7 @@ class ArrowFunctionTest extends BaseTestCase
 			63,
 			67,
 			71,
+			87,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -77,3 +77,13 @@ function arrowFunctionWithVariableUsedInsideQuotes($allowed_extensions) {
     $data = array_map( fn($extension) => ".{$extension}", $allowed_extensions );
     return $data;
 }
+
+function staticArrowFunctionAsVariableWithUsedInside($subject) {
+    $arrowFunc = static fn($foo) => $foo . $subject;
+    echo $arrowFunc('hello');
+}
+
+function staticArrowFunctionAsVariableWithUnusedInside($subject) {
+    $arrowFunc = static fn($foo) => $subject; // unused variable $foo
+    echo $arrowFunc('hello');
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1313,7 +1313,7 @@ class VariableAnalysisSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		// Search backwards for a `static` keyword that occurs before the start of the statement.
-		$startOfStatement = $phpcsFile->findPrevious([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $stackPtr - 1, null, false, null, true);
+		$startOfStatement = $phpcsFile->findPrevious([T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_FN_ARROW], $stackPtr - 1, null, false, null, true);
 		$staticPtr = $phpcsFile->findPrevious([T_STATIC], $stackPtr - 1, null, false, null, true);
 		if (! is_int($startOfStatement)) {
 			$startOfStatement = 1;


### PR DESCRIPTION
Provides a fix for #275, adding the following:

- Places the static arrow function body outside of scope on static declaration checks.
- Added a tests for used and unused variable usage on static arrow functions.


Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/275