### PR TITLE
Fix function call detection to exclude non-function tokens

### DIFF
--- a/Tests/VariableAnalysisSniff/ForLoopTest.php
+++ b/Tests/VariableAnalysisSniff/ForLoopTest.php
@@ -23,6 +23,8 @@ class ForLoopTest extends BaseTestCase
 			118,
 			123,
 			129,
+			143,
+			145,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -43,5 +45,7 @@ class ForLoopTest extends BaseTestCase
 		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[118][5][0]['source']);
 		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[123][5][0]['source']);
 		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[129][14][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[143][5][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[145][3][0]['source']);
 	}
 }

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
@@ -101,3 +101,11 @@ function function_with_static_closure() {
         echo $inner_param;
     }, $params);
 }
+
+function function_with_static_variable_inside_anonymous_function() {
+    $anon = (function() {
+      static $test;
+      echo $test;
+    });
+    $anon();
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithClosureFixture.php
@@ -109,3 +109,10 @@ function function_with_static_variable_inside_anonymous_function() {
     });
     $anon();
 }
+
+function function_with_static_variable_inside_anonymous_function_inside_arguments() {
+    add_action('test', function () {
+      static $providerId;
+      echo $providerId;
+    });
+}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
@@ -139,7 +139,13 @@ function veryBoringForLoop() {
 }
 
 function reallySmallForLoop() {
-  for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+  for ($i = 1,
+    $j = 0;
+  $i <= 10;
+  $j += $i,
+    print $i +
+    $j,
+    $i++);
 }
 
 function colonSyntaxForLoop() {

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithForLoopFixture.php
@@ -138,6 +138,15 @@ function veryBoringForLoop() {
   }
 }
 
+function reallySmallForLoopWithUnusedInitVar() {
+  for ($i = 1,
+    $j = 0; // Unused variable $j
+  $i <= 10;
+  $j += $i, // Unused variable $j
+    print $i,
+    $i++);
+}
+
 function reallySmallForLoop() {
   for ($i = 1,
     $j = 0;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1112,6 +1112,12 @@ class Helpers
 			return null;
 		}
 
+		if ($tokens[$functionPtr]['level'] !== $tokens[$stackPtr]['level']) {
+			// If the variable is inside a different scope than the function name,
+			// the function call doesn't apply to the variable.
+			return null;
+		}
+
 		return $functionPtr;
 	}
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1092,12 +1092,26 @@ class Helpers
 		if (! is_int($functionPtr) || ! isset($tokens[$functionPtr]['code'])) {
 			return null;
 		}
-		if ($tokens[$functionPtr]['content'] === 'function' || ($tokens[$functionPtr]['content'] === 'fn' && self::isArrowFunction($phpcsFile, $functionPtr))) {
+		if (
+			$tokens[$functionPtr]['content'] === 'function'
+			|| ($tokens[$functionPtr]['content'] === 'fn' && self::isArrowFunction($phpcsFile, $functionPtr))
+		) {
+			// If there is a function/fn keyword before the beginning of the parens,
+			// this is a function definition and not a function call.
 			return null;
 		}
 		if (! empty($tokens[$functionPtr]['scope_opener'])) {
+			// If the alleged function name has a scope, this is not a function call.
 			return null;
 		}
+
+		$functionNameType = $tokens[$functionPtr]['code'];
+		if (! in_array($functionNameType, Tokens::$functionNameTokens, true)) {
+			// If the alleged function name is not a variable or a string, this is
+			// not a function call.
+			return null;
+		}
+
 		return $functionPtr;
 	}
 


### PR DESCRIPTION
The helper function `getFunctionIndexForFunctionCallArgument()` (and by association `isTokenInsideFunctionCallArgument()`) tries to return the position of the function name token for a function call argument (eg: in the expression `greet($user)` it would return the token position for `greet` for the variable `$user`). It does this by finding the nearest enclosing parentheses and then looking at the non-whitespace token that comes before it. If that token does not look like a function _definition_, then it assumes it is a function _call_.

Unfortunately, this is too naive and will consider things like equals signs as function calls.

In this PR we modify the function to also reject anything not in PHPCS's list of valid function call token types and anything not in the same scope level.

Fixing this also fixed another bug, which had not been caught because one of the for loop tests was mis-written. Some variables inside for loops were being considered reads as well as writes. 

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/277