### PR TITLE
GH Actions: various tweaks / PHP 8.2 not allowed to fail

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   checkcs:
-    name: 'PHP: 7.4 | Basic CS and QA checks'
+    name: 'Basic CS and QA checks'
     runs-on: ubuntu-latest
 
     env:
@@ -31,7 +31,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 
@@ -75,7 +75,7 @@ jobs:
         run: cs2pr ./phpcs-report.xml
 
   static-analysis:
-    name: "PHP: 7.4 | Static Analysis"
+    name: "PHPStan & Psalm"
     runs-on: ubuntu-latest
 
     steps:
@@ -85,7 +85,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
 
       # Install dependencies and handle caching in one go.

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install xmllint
         run: |
@@ -94,8 +94,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run Static Analysis
         run: composer static-analysis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         # - PHPCS will run without errors on PHP 5.4 - 7.4 on all supported PHPCS versions.
         # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
         # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
+        # - PHP 8.2 needs PHPCS 3.6.1+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3']
@@ -36,6 +37,11 @@ jobs:
 
         include:
           # Make the matrix complete without duplicating builds run in code coverage.
+          - php: '8.2'
+            phpcs_version: '3.6.1'
+
+          - php: '8.1'
+            phpcs_version: 'dev-master'
           - php: '8.1'
             phpcs_version: '3.6.1'
 
@@ -48,12 +54,12 @@ jobs:
             phpcs_version: 'dev-master'
 
           # Experimental builds.
-          - php: '8.2' # Nightly.
+          - php: '8.3' # Nightly.
             phpcs_version: 'dev-master'
 
     name: "Test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout code
@@ -87,7 +93,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.2' }}
+        if: ${{ matrix.php != '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -95,7 +101,7 @@ jobs:
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.2' }}
+        if: ${{ matrix.php == '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php
@@ -115,7 +121,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '8.1'
+          - php: '8.2'
             phpcs_version: 'dev-master'
           - php: '7.4'
             phpcs_version: '3.5.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,8 @@ jobs:
         if: ${{ matrix.php != '8.2' }}
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
@@ -99,7 +99,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run the unit tests
         run: composer test
@@ -158,8 +158,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Grab PHPUnit version
         id: phpunit_version


### PR DESCRIPTION
### GH Actions: use PHP latest

... for those tasks where the PHP version isn't (or shouldn't be) that relevant.

Includes updating the task name to not include the PHP version (`latest` will roll on automatically).

### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Note: PHPCS does not (yet) have full syntax support for PHP 8.2, but it does have runtime support (for the most part, see squizlabs/PHP_CodeSniffer#3629).

Builds against PHP 8.3 are still allowed to fail for now.