### PR TITLE
Add explicit types for 'nested_parenthesis'

### DIFF
--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -69,6 +69,9 @@ class Helpers
 	{
 		$tokens = $phpcsFile->getTokens();
 		if (isset($tokens[$stackPtr]['nested_parenthesis'])) {
+			/**
+		 	 * @var array<int|null>
+		 	 */
 			$openPtrs = array_keys($tokens[$stackPtr]['nested_parenthesis']);
 			return (int)end($openPtrs);
 		}
@@ -1081,6 +1084,9 @@ class Helpers
 		if (empty($token['nested_parenthesis'])) {
 			return null;
 		}
+		/**
+		 * @var array<int|null>
+		 */
 		$startingParenthesis = array_keys($token['nested_parenthesis']);
 		$startOfArguments = end($startingParenthesis);
 		if (! is_int($startOfArguments)) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -70,8 +70,8 @@ class Helpers
 		$tokens = $phpcsFile->getTokens();
 		if (isset($tokens[$stackPtr]['nested_parenthesis'])) {
 			/**
-		 	 * @var array<int|null>
-		 	 */
+			 * @var array<int|string|null>
+			 */
 			$openPtrs = array_keys($tokens[$stackPtr]['nested_parenthesis']);
 			return (int)end($openPtrs);
 		}
@@ -1085,7 +1085,7 @@ class Helpers
 			return null;
 		}
 		/**
-		 * @var array<int|null>
+		 * @var array<int|string|null>
 		 */
 		$startingParenthesis = array_keys($token['nested_parenthesis']);
 		$startOfArguments = end($startingParenthesis);


### PR DESCRIPTION
This adds PHPDoc types when accessing the keys of the 'nested_parenthesis' property of tokens. From what I know, the type of that property is always `array<int, int>`, but for some reason in the most recent update of Psalm it no longer is able to figure that out, so here we add explicit types for it.

I'm not sure if the keys can ever be some other type, but just in case this type allows them to be either string or null also.