### PR TITLE
Composer: allow for the 1.0.0 version of the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "sirbrillig/phpcs-import-detection": "^1.1",
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
         "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
     }
 }


### PR DESCRIPTION
The Composer PHPCS plugin has released its 1.0.0 version. :tada:

Ref: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0