### PR TITLE
Add support for enum methods

### DIFF
--- a/Tests/VariableAnalysisSniff/EnumTest.php
+++ b/Tests/VariableAnalysisSniff/EnumTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace VariableAnalysis\Tests\VariableAnalysisSniff;
+
+use VariableAnalysis\Tests\BaseTestCase;
+
+class EnumTest extends BaseTestCase
+{
+	public function testEnum()
+	{
+		$fixtureFile = $this->getFixture('EnumFixture.php');
+		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+		$phpcsFile->process();
+		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedWarnings = [
+			33,
+		];
+		$this->assertEquals($expectedWarnings, $lines);
+	}
+}

--- a/Tests/VariableAnalysisSniff/fixtures/EnumFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/EnumFixture.php
@@ -1,0 +1,39 @@
+<?php
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+
+enum BackedSuit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+enum Numbers: string {
+  case ONE   = '1';
+  case TWO   = '2';
+  case THREE = '3';
+  case FOUR  = '4';
+
+  public function divisibility(): string {
+    return match ($this) {
+      self::ONE, self::THREE => 'odd',
+      self::TWO, self::FOUR => 'even',
+    };
+  }
+
+  public function foobar(): string {
+    return match ($foo) { // undefined variable $foo
+      'x' => 'first',
+      'y' => 'second',
+      default => 'unknown',
+    };
+  }
+}

--- a/VariableAnalysis/Lib/EnumInfo.php
+++ b/VariableAnalysis/Lib/EnumInfo.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace VariableAnalysis\Lib;
+
+/**
+ * Holds details of an enum.
+ */
+class EnumInfo
+{
+	/**
+	 * The position of the `enum` token.
+	 *
+	 * @var int
+	 */
+	public $enumIndex;
+
+	/**
+	 * The position of the block opener (curly brace) for the enum.
+	 *
+	 * @var int
+	 */
+	public $blockStart;
+
+	/**
+	 * The position of the block closer (curly brace) for the enum.
+	 *
+	 * @var int
+	 */
+	public $blockEnd;
+
+	/**
+	 * @param int $enumIndex
+	 * @param int $blockStart
+	 * @param int $blockEnd
+	 */
+	public function __construct(
+		$enumIndex,
+		$blockStart,
+		$blockEnd
+	) {
+		$this->enumIndex = $enumIndex;
+		$this->blockStart = $blockStart;
+		$this->blockEnd = $blockEnd;
+	}
+}


### PR DESCRIPTION
This adds support for `enum` methods to behave like `class` methods.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/288