### PR TITLE
GH Actions: various tweaks / fix code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,9 +198,10 @@ jobs:
           php-version: 7.4
           coverage: none
 
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.5.2" --no-interaction --with-all-dependencies
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction --with-all-dependencies
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
@@ -208,7 +209,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
-        run: vendor/bin/php-coveralls -v -x build/logs/clover.xml
+        run: php-coveralls -v -x build/logs/clover.xml
 
   coveralls-finish:
     needs: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
### GH Actions: used a named branch for coverallsapp

The `coverallsapp/github-action` action runner has (finally) created a named branch for the 1.x series, so let's use that.

Ref: https://github.com/coverallsapp/github-action/issues/100

### GH Actions: fix CI
Grrr....

When PHPUnit has been installed on a high PHP version, some of the dependencies of PHPUnit will now be installed in versions not compatible with PHP 7.4, which blocks the install of the Coveralls package.

Installing PHP Coveralls globally instead should fix it.

I just wish PHP Coveralls would finally release a version compatible with PHP >  8.0....