### PR TITLE
Allow non-enum tokens called 'enum'

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/EnumFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/EnumFixture.php
@@ -37,3 +37,15 @@ enum Numbers: string {
     };
   }
 }
+
+final class Test
+{
+    public function __construct(private SomeClass $someClass)
+    {
+    }
+
+    public function createFor()
+    {
+        $this->someClass->enum('test');
+    }
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1298,7 +1298,7 @@ class Helpers
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr
 	 *
-	 * @return EnumInfo
+	 * @return EnumInfo|null
 	 */
 	public static function makeEnumInfo(File $phpcsFile, $stackPtr)
 	{
@@ -1314,7 +1314,7 @@ class Helpers
 
 			$blockStart = $phpcsFile->findNext([T_OPEN_CURLY_BRACKET], $stackPtr + 1);
 			if (! is_int($blockStart)) {
-				throw new \Exception("Cannot find enum start at position {$stackPtr}");
+				return null;
 			}
 			$blockEnd = $tokens[$blockStart]['bracket_closer'];
 		}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -314,7 +314,7 @@ class VariableAnalysisSniff implements Sniff
 	private function recordEnum($phpcsFile, $stackPtr)
 	{
 		$enumInfo = Helpers::makeEnumInfo($phpcsFile, $stackPtr);
-		if ( $enumInfo ) {
+		if ($enumInfo) {
 			$this->enums[$stackPtr] = $enumInfo;
 		}
 	}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -313,7 +313,10 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	private function recordEnum($phpcsFile, $stackPtr)
 	{
-		$this->enums[$stackPtr] = Helpers::makeEnumInfo($phpcsFile, $stackPtr);
+		$enumInfo = Helpers::makeEnumInfo($phpcsFile, $stackPtr);
+		if ( $enumInfo ) {
+			$this->enums[$stackPtr] = $enumInfo;
+		}
 	}
 
 	/**

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -278,8 +278,13 @@ class VariableAnalysisSniff implements Sniff
 
 		// Record enums so we can detect them even before phpcs was able to.
 		if ($token['content'] === 'enum') {
-			$this->recordEnum($phpcsFile, $stackPtr);
-			return;
+			$enumInfo = Helpers::makeEnumInfo($phpcsFile, $stackPtr);
+			// The token might not actually be an enum so let's avoid returning if
+			// it's not.
+			if ($enumInfo) {
+				$this->enums[$stackPtr] = $enumInfo;
+				return;
+			}
 		}
 
 		// If the current token is a call to `get_defined_vars()`, consider that a
@@ -300,22 +305,6 @@ class VariableAnalysisSniff implements Sniff
 			Helpers::debug('found scope condition', $token);
 			$this->scopeManager->recordScopeStartAndEnd($phpcsFile, $stackPtr);
 			return;
-		}
-	}
-
-	/**
-	 * Record the boundaries of an enum.
-	 *
-	 * @param File $phpcsFile
-	 * @param int  $stackPtr
-	 *
-	 * @return void
-	 */
-	private function recordEnum($phpcsFile, $stackPtr)
-	{
-		$enumInfo = Helpers::makeEnumInfo($phpcsFile, $stackPtr);
-		if ($enumInfo) {
-			$this->enums[$stackPtr] = $enumInfo;
 		}
 	}
 


### PR DESCRIPTION
When enum detection was added in #289 it used the string `'enum'` to detect enums in versions of PHPCS where the tokenizer is unaware of enums. However, this accidentally caused it to detect non-enums as well if they have the content '`enum`'.

In this diff we make enum detection safely fail if the token does not look like an enum.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/292