### PR TITLE
Add readonly constructor promotion support

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -183,3 +183,15 @@ class ClassWithStaticCreateMethod {
   }
 
 }
+
+class ClassWithReadonlyConstructorPromotion {
+  public function __construct(
+    private readonly string $message,
+    private readonly $name,
+    public readonly bool $key
+  ) {}
+
+  public function getMessage(): string {
+    return $this->message;
+  }
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1445,11 +1445,11 @@ class Helpers
 
 		// If the previous token is a visibility keyword, this is constructor
 		// promotion. eg: `public $foobar`.
-		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), $functionIndex, true);
-		if (! is_int($prev)) {
+		$prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), $functionIndex, true);
+		if (! is_int($prevIndex)) {
 			return false;
 		}
-		$prevToken = $tokens[$prev];
+		$prevToken = $tokens[$prevIndex];
 		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
 			return true;
 		}
@@ -1457,12 +1457,31 @@ class Helpers
 		// If the previous token is not a visibility keyword, but the one before it
 		// is, the previous token was probably a typehint and this is constructor
 		// promotion. eg: `public boolean $foobar`.
-		$prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), $functionIndex, true);
-		if (! is_int($prev)) {
+		$prev2Index = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevIndex - 1), $functionIndex, true);
+		if (! is_int($prev2Index)) {
 			return false;
 		}
-		$prevToken = $tokens[$prev];
-		if (in_array($prevToken['code'], Tokens::$scopeModifiers, true)) {
+		$prev2Token = $tokens[$prev2Index];
+		if (in_array($prev2Token['code'], Tokens::$scopeModifiers, true)) {
+			return true;
+		}
+
+		// If the previous token is not a visibility keyword, but the one two
+		// before it is, and one of the tokens is `readonly`, the previous token
+		// was probably a typehint and this is constructor promotion. eg: `public
+		// readonly boolean $foobar`.
+		$prev3Index = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev2Index - 1), $functionIndex, true);
+		if (! is_int($prev3Index)) {
+			return false;
+		}
+		$prev3Token = $tokens[$prev3Index];
+		if (
+			in_array($prev3Token['code'], Tokens::$scopeModifiers, true) &&
+			(
+				$prevToken['content'] === 'readonly' ||
+				$prev2Token['content'] === 'readonly'
+			)
+		) {
 			return true;
 		}
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1475,13 +1475,8 @@ class Helpers
 			return false;
 		}
 		$prev3Token = $tokens[$prev3Index];
-		if (
-			in_array($prev3Token['code'], Tokens::$scopeModifiers, true) &&
-			(
-				$prevToken['content'] === 'readonly' ||
-				$prev2Token['content'] === 'readonly'
-			)
-		) {
+		$wasPreviousReadonly = $prevToken['content'] === 'readonly' || $prev2Token['content'] === 'readonly';
+		if (in_array($prev3Token['code'], Tokens::$scopeModifiers, true) && $wasPreviousReadonly) {
 			return true;
 		}
 


### PR DESCRIPTION
This adds support for `readonly` constructor promotion.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/290