### PR TITLE
Use custom logic for finding arrow function scope

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -87,3 +87,8 @@ function staticArrowFunctionAsVariableWithUnusedInside($subject) {
     $arrowFunc = static fn($foo) => $subject; // unused variable $foo
     echo $arrowFunc('hello');
 }
+
+function arrowFunctionAsExpressionInArgumentWithArray() {
+    $type = do_something(fn($array, $needle) => $array[2] === $needle);
+    echo $type;
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -628,12 +628,6 @@ class Helpers
 	public static function getArrowFunctionOpenClose(File $phpcsFile, $stackPtr)
 	{
 		$tokens = $phpcsFile->getTokens();
-		if (defined('T_FN') && $tokens[$stackPtr]['code'] === T_FN) {
-			return [
-				'scope_opener' => $tokens[$stackPtr]['scope_opener'],
-				'scope_closer' => $tokens[$stackPtr]['scope_closer'],
-			];
-		}
 		if ($tokens[$stackPtr]['content'] !== 'fn') {
 			return null;
 		}


### PR DESCRIPTION
It appears that at least in some versions of phpcs, the arrow function scope detection is not correct. It incorrectly considers a closing square bracket (`]`) inside the body of an arrow function to close that arrow function's scope.

We already have custom logic for finding arrow function scopes so that it will work for versions of PHP/phpcs which do not support arrow functions. In this PR we remove the simpler path and rely only on the custom logic.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/295