### PR TITLE
Fix scope closer detection in arrow function detection

### DIFF
--- a/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
+++ b/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
@@ -30,6 +30,8 @@ class ArrowFunctionTest extends BaseTestCase
 			67,
 			71,
 			87,
+			102,
+			112,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -60,6 +62,8 @@ class ArrowFunctionTest extends BaseTestCase
 			67,
 			71,
 			87,
+			102,
+			112,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -113,3 +113,7 @@ function arrowFunctionAsExpressionWithUndefinedAfterComma() {
     echo $type;
 }
 
+function arrowFunctionAsExpressionInArgumentWithInnerArrayAndArgs() {
+    $type = do_something(fn(Thing $func) => $func->call([1,2]) ? $func : null);
+    echo $type;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -117,3 +117,8 @@ function arrowFunctionAsExpressionInArgumentWithInnerArrayAndArgs() {
     $type = do_something(fn(Thing $func) => $func->call([1,2]) ? $func : null);
     echo $type;
 }
+
+function arrowFunctionAsExpressionInArgumentWithSimpleTernary() {
+    $type = do_something(fn(Thing $func) => $func ? $func : null);
+    echo $type;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -122,3 +122,8 @@ function arrowFunctionAsExpressionInArgumentWithSimpleTernary() {
     $type = do_something(fn(Thing $func) => $func ? $func : null);
     echo $type;
 }
+
+function arrowFunctionWithReturnType() {
+    $type = do_something(fn(string $func): string => $func ? $func : '');
+    echo $type;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -93,7 +93,23 @@ function arrowFunctionAsExpressionInArgumentWithArray() {
     echo $type;
 }
 
-function arrowFunctionAsExpressionInArgumentWithTernary() {
+function arrowFunctionAsExpressionInArgumentWithInnerCall() {
     $type = do_something(fn(Thing $func) => $func->call() ? $func : null);
     echo $type;
 }
+
+function arrowFunctionAsExpressionInArgumentWithInnerCallAndUndefinedAfterTernary() {
+    $type = do_something(fn(Thing $func) => $func->call() ? $func : $foo); // undefined variable $foo
+    echo $type;
+}
+
+function arrowFunctionAsExpressionInArgumentWithInnerCallAndArgs() {
+    $type = do_something(fn(Thing $func) => $func->call(1,2) ? $func : null);
+    echo $type;
+}
+
+function arrowFunctionAsExpressionWithUndefinedAfterComma() {
+    $type = do_something(fn(Thing $func, $bar) => $func->call(1,2) ? $bar : null, $bar); // undefined variable $bar
+    echo $type;
+}
+

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -92,3 +92,8 @@ function arrowFunctionAsExpressionInArgumentWithArray() {
     $type = do_something(fn($array, $needle) => $array[2] === $needle);
     echo $type;
 }
+
+function arrowFunctionAsExpressionInArgumentWithTernary() {
+    $type = do_something(fn(Thing $func) => $func->call() ? $func : null);
+    echo $type;
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -653,7 +653,8 @@ class Helpers
 		$foundArrayPairs = 0;
 		$foundParenPairs = 0;
 		$arrowBodyStart = $tokens[$stackPtr]['parenthesis_closer'] + 1;
-		for ($index = $arrowBodyStart; $index < self::getLastNonEmptyTokenIndexInFile($phpcsFile); $index++) {
+		$lastToken = self::getLastNonEmptyTokenIndexInFile($phpcsFile);
+		for ($index = $arrowBodyStart; $index < $lastToken; $index++) {
 			$token = $tokens[$index];
 			if (empty($token['code'])) {
 				$scopeCloserIndex = $index;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -661,7 +661,9 @@ class Helpers
 			if (! is_int($scopeCloserIndex)) {
 				break;
 			}
-			if (count($tokens[$scopeCloserIndex]['nested_parenthesis'] ?? []) !== count($tokens[$stackPtr]['nested_parenthesis'] ?? [])) {
+			$parensOfScopeCloser = isset( $tokens[$scopeCloserIndex]['nested_parenthesis'] ) ? $tokens[$scopeCloserIndex]['nested_parenthesis'] : [];
+			$parensOfFn = isset( $tokens[$stackPtr]['nested_parenthesis'] ) ? $tokens[$stackPtr]['nested_parenthesis'] : [];
+			if (count($parensOfScopeCloser) !== count($parensOfFn)) {
 				// If the alleged scope closer is inside a function parameter, it's not
 				// a closer.
 				$lastIndex = $scopeCloserIndex + 1;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -650,14 +650,14 @@ class Helpers
 		$endScopeTokens = [
 			T_COMMA,
 			T_SEMICOLON,
-			T_CLOSE_PARENTHESIS,
 			T_CLOSE_CURLY_BRACKET,
 			T_CLOSE_SHORT_ARRAY,
 		];
-		$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $fatArrowIndex	+ 1);
+		$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $fatArrowIndex + 1);
 		if (! is_int($scopeCloserIndex)) {
 			return null;
 		}
+
 		return [
 			'scope_opener' => $stackPtr,
 			'scope_closer' => $scopeCloserIndex,

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -653,7 +653,23 @@ class Helpers
 			T_CLOSE_CURLY_BRACKET,
 			T_CLOSE_SHORT_ARRAY,
 		];
-		$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $fatArrowIndex + 1);
+		$foundCloser = false;
+		$scopeCloserIndex = null;
+		$lastIndex = $fatArrowIndex;
+		while($foundCloser === false) {
+			$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $lastIndex + 1);
+			if (! is_int($scopeCloserIndex)) {
+				break;
+			}
+			if (count($tokens[$scopeCloserIndex]['nested_parenthesis'] ?? []) !== count($tokens[$stackPtr]['nested_parenthesis'] ?? [])) {
+				// If the alleged scope closer is inside a function parameter, it's not
+				// a closer.
+				$lastIndex = $scopeCloserIndex + 1;
+				continue;
+			}
+			$foundCloser = true;
+			break;
+		}
 		if (! is_int($scopeCloserIndex)) {
 			return null;
 		}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -656,13 +656,13 @@ class Helpers
 		$foundCloser = false;
 		$scopeCloserIndex = null;
 		$lastIndex = $fatArrowIndex;
-		while($foundCloser === false) {
+		while ($foundCloser === false) {
 			$scopeCloserIndex = $phpcsFile->findNext($endScopeTokens, $lastIndex + 1);
 			if (! is_int($scopeCloserIndex)) {
 				break;
 			}
-			$parensOfScopeCloser = isset( $tokens[$scopeCloserIndex]['nested_parenthesis'] ) ? $tokens[$scopeCloserIndex]['nested_parenthesis'] : [];
-			$parensOfFn = isset( $tokens[$stackPtr]['nested_parenthesis'] ) ? $tokens[$stackPtr]['nested_parenthesis'] : [];
+			$parensOfScopeCloser = isset($tokens[$scopeCloserIndex]['nested_parenthesis']) ? $tokens[$scopeCloserIndex]['nested_parenthesis'] : [];
+			$parensOfFn = isset($tokens[$stackPtr]['nested_parenthesis']) ? $tokens[$stackPtr]['nested_parenthesis'] : [];
 			if (count($parensOfScopeCloser) !== count($parensOfFn)) {
 				// If the alleged scope closer is inside a function parameter, it's not
 				// a closer.

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -664,7 +664,7 @@ class Helpers
 			$parensOfScopeCloser = isset($tokens[$scopeCloserIndex]['nested_parenthesis']) ? $tokens[$scopeCloserIndex]['nested_parenthesis'] : [];
 			$parensOfFn = isset($tokens[$stackPtr]['nested_parenthesis']) ? $tokens[$stackPtr]['nested_parenthesis'] : [];
 			if (count($parensOfScopeCloser) !== count($parensOfFn)) {
-				// If the alleged scope closer is inside a function parameter, it's not
+				// If the alleged scope closer is inside a function argument, it's not
 				// a closer.
 				$lastIndex = $scopeCloserIndex + 1;
 				continue;
@@ -672,6 +672,10 @@ class Helpers
 			$foundCloser = true;
 			break;
 		}
+		if (! is_int($scopeCloserIndex) && !empty($tokens[$stackPtr]['scope_closer'])) {
+			$scopeCloserIndex = $tokens[$stackPtr]['scope_closer'];
+		}
+
 		if (! is_int($scopeCloserIndex)) {
 			return null;
 		}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -639,7 +639,6 @@ class Helpers
 		// Find the associated close parenthesis
 		$closeParenIndex = $tokens[$openParenIndex]['parenthesis_closer'];
 		// Make sure the next token is a fat arrow or a return type
-		$nonFunctionTokenTypes[] = T_OPEN_PARENTHESIS;
 		$fatArrowIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closeParenIndex + 1, null, true);
 		if (! is_int($fatArrowIndex)) {
 			return null;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -638,12 +638,17 @@ class Helpers
 		}
 		// Find the associated close parenthesis
 		$closeParenIndex = $tokens[$openParenIndex]['parenthesis_closer'];
-		// Make sure the next token is a fat arrow
+		// Make sure the next token is a fat arrow or a return type
+		$nonFunctionTokenTypes[] = T_OPEN_PARENTHESIS;
 		$fatArrowIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closeParenIndex + 1, null, true);
 		if (! is_int($fatArrowIndex)) {
 			return null;
 		}
-		if ($tokens[$fatArrowIndex]['code'] !== T_DOUBLE_ARROW && $tokens[$fatArrowIndex]['type'] !== 'T_FN_ARROW') {
+		if (
+			$tokens[$fatArrowIndex]['code'] !== T_DOUBLE_ARROW &&
+			$tokens[$fatArrowIndex]['type'] !== 'T_FN_ARROW' &&
+			$tokens[$fatArrowIndex]['code'] !== T_COLON
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
The arrow function scope closer detection is very difficult. This PR improves it. I'm sure there are still bugs but we'll have to get more test cases to find them.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/297
Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/299
