### PR TITLE
Allow newlines in arrow functions

### DIFF
--- a/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
+++ b/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
@@ -32,6 +32,7 @@ class ArrowFunctionTest extends BaseTestCase
 			87,
 			102,
 			112,
+			150,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -64,6 +65,7 @@ class ArrowFunctionTest extends BaseTestCase
 			87,
 			102,
 			112,
+			150,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -129,16 +129,26 @@ function arrowFunctionWithReturnType() {
 }
 
 function arrowFunctionWithNewlines( $items ): array {
-    return $items
-      ->map(
-        fn ( array $item ) => apply_overrides(
-          [
-            'a' => ! empty( $item['b'] ),
-          ],
-          $item, // throws an undefined variable error
-        )
+  return $items
+    ->map(
+      fn ( array $item ) => apply_overrides(
+        [
+          'a' => ! empty( $item['b'] ),
+        ],
+        $item,
       )
-      ->filter( fn ( array $item ) => ! empty( $item['post'] ) )
-      ->values()
-      ->all();
-  }
+    )
+    ->filter( fn ( array $item ) => ! empty( $item['post'] ) )
+    ->values()
+    ->all();
+}
+
+function arrowFunctionWithNewClass(): array {
+  $arrow = fn($a) => new class($a) {
+    public function __construct($key) {
+      $this->key = $key;
+      echo $bar; // undefined variable $bar
+    }
+  };
+  echo $arrow;
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -152,3 +152,17 @@ function arrowFunctionWithNewClass(): array {
   };
   echo $arrow;
 }
+
+function arrowFunctionWithQuotes($allowedReferrers) {
+  array_map(
+    static fn (string $allowedReferrer) => str_replace(
+      ['\*\*', '\*'],
+      ['[a-z\d.-]{0,63}', '[a-z\d-]{0,63}'],
+      preg_quote($allowedReferrer, '~'),
+    ),
+    $allowedReferrers;
+  do_something(
+    static fn (string $permissionName) => Str::startsWith($permissionName, CONFIG_START)
+    && $permissionName !== CustomPermission::ALL_CONFIG
+  );
+}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -127,3 +127,18 @@ function arrowFunctionWithReturnType() {
     $type = do_something(fn(string $func): string => $func ? $func : '');
     echo $type;
 }
+
+function arrowFunctionWithNewlines( $items ): array {
+    return $items
+      ->map(
+        fn ( array $item ) => apply_overrides(
+          [
+            'a' => ! empty( $item['b'] ),
+          ],
+          $item, // throws an undefined variable error
+        )
+      )
+      ->filter( fn ( array $item ) => ! empty( $item['post'] ) )
+      ->values()
+      ->all();
+  }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -665,11 +665,6 @@ class Helpers
 				break;
 			}
 
-			// A line break is always a closer.
-			if ($token['line'] !== $tokens[$stackPtr]['line']) {
-				$scopeCloserIndex = $index;
-				break;
-			}
 			$code = $token['code'];
 
 			// A semicolon is always a closer.


### PR DESCRIPTION
I was under the impression that arrow functions could not contain newlines but I was wrong.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/300
Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/299