### PR TITLE
Make test suite compatible with PHPCS 3.8.0

### DIFF
--- a/Tests/BaseTestCase.php
+++ b/Tests/BaseTestCase.php
@@ -58,4 +58,24 @@ class BaseTestCase extends TestCase
 	{
 		return realpath(__DIR__ . '/VariableAnalysisSniff/fixtures/' . $fixtureFilename);
 	}
+
+	public function setSniffProperty($phpcsFile, $property, $value)
+	{
+		if (version_compare(Config::VERSION, '3.8.0', '>=')) {
+			$phpcsFile->ruleset->setSniffProperty(
+				'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+				$property,
+				[
+					'scope' => 'sniff',
+					'value' => $value,
+				]
+			);
+		} else {
+			$phpcsFile->ruleset->setSniffProperty(
+				'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
+				$property,
+				$value
+			);
+		}
+	}
 }

--- a/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
+++ b/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
@@ -10,11 +10,7 @@ class ArrowFunctionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ArrowFunctionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -41,11 +37,7 @@ class ArrowFunctionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ArrowFunctionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [

--- a/Tests/VariableAnalysisSniff/GlobalScopeTest.php
+++ b/Tests/VariableAnalysisSniff/GlobalScopeTest.php
@@ -10,11 +10,7 @@ class GlobalScopeTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('GlobalScopeFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUndefinedVariablesInFileScope',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUndefinedVariablesInFileScope', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
@@ -31,11 +27,7 @@ class GlobalScopeTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('GlobalScopeFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUndefinedVariablesInFileScope',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUndefinedVariablesInFileScope', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
@@ -51,11 +43,7 @@ class GlobalScopeTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('GlobalScopeFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedVariablesInFileScope',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedVariablesInFileScope', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [

--- a/Tests/VariableAnalysisSniff/IfConditionTest.php
+++ b/Tests/VariableAnalysisSniff/IfConditionTest.php
@@ -10,11 +10,7 @@ class IfConditionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithIfConditionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -43,16 +39,8 @@ class IfConditionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithIfConditionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUndefinedVariableNames',
-			'second'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'validUndefinedVariableNames', 'second');
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -75,11 +63,7 @@ class IfConditionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithInlineIfConditionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -110,16 +94,8 @@ class IfConditionTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithInlineIfConditionFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUndefinedVariableNames',
-			'second'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'validUndefinedVariableNames', 'second');
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [

--- a/Tests/VariableAnalysisSniff/UnusedFollowedByRequireTest.php
+++ b/Tests/VariableAnalysisSniff/UnusedFollowedByRequireTest.php
@@ -33,11 +33,7 @@ class UnusedFollowedByRequire extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('UnusedFollowedByRequireFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedVariablesBeforeRequire',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedVariablesBeforeRequire', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -53,11 +49,7 @@ class UnusedFollowedByRequire extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithoutParamFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedVariablesBeforeRequire',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedVariablesBeforeRequire', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [

--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -53,11 +53,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithDefaultParamFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getErrorLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [];
@@ -68,11 +64,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithDefaultParamFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -125,11 +117,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithForeachFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedForeachVariables',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedForeachVariables', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -187,11 +175,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ClassWithMembersFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -240,11 +224,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithClosureFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getErrorLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [
@@ -258,11 +238,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithClosureFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -328,11 +304,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithReferenceFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'sitePassByRefFunctions',
-			'my_reference_function:2,3 another_reference_function:2,...'
-		);
+		$this->setSniffProperty($phpcsFile, 'sitePassByRefFunctions', 'my_reference_function:2,3 another_reference_function:2,...');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -361,11 +333,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithReferenceFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowWordPressPassByRefFunctions',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowWordPressPassByRefFunctions', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -529,11 +497,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('CompactFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getErrorLineNumbersFromFile($phpcsFile);
 		$expectedErrors = [];
@@ -544,11 +508,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('CompactFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -568,11 +528,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('CompactFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
@@ -617,11 +573,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithVariableCallFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [18];
@@ -690,11 +642,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -712,11 +660,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 
 		$warnings = $phpcsFile->getWarnings();
@@ -733,16 +677,8 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUnusedVariableNames',
-			'ignored'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
+		$this->setSniffProperty($phpcsFile, 'validUnusedVariableNames', 'ignored');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -759,16 +695,8 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedFunctionParameters',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
+		$this->setSniffProperty($phpcsFile, 'allowUnusedFunctionParameters', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [];
@@ -779,16 +707,8 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedCaughtExceptions',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
+		$this->setSniffProperty($phpcsFile, 'allowUnusedCaughtExceptions', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -806,16 +726,8 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedCaughtExceptions',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
+		$this->setSniffProperty($phpcsFile, 'allowUnusedCaughtExceptions', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -834,16 +746,8 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithUnusedParamsFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'ignoreUnusedRegexp',
-			'/^unused_/'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
+		$this->setSniffProperty($phpcsFile, 'ignoreUnusedRegexp', '/^unused_/');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -877,11 +781,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('FunctionWithGlobalVarFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUndefinedVariableNames',
-			'ice_cream'
-		);
+		$this->setSniffProperty($phpcsFile, 'validUndefinedVariableNames', 'ice_cream');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -898,11 +798,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ClassReferenceFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUndefinedVariableNames',
-			'ignored_property'
-		);
+		$this->setSniffProperty($phpcsFile, 'validUndefinedVariableNames', 'ignored_property');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -920,11 +816,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('ClassReferenceFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'validUndefinedVariableRegexp',
-			'/^undefined_/'
-		);
+		$this->setSniffProperty($phpcsFile, 'validUndefinedVariableRegexp', '/^undefined_/');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -940,11 +832,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('UnusedAfterUsedFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -1012,11 +900,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('UnusedForeachFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedForeachVariables',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedForeachVariables', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -1040,11 +924,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('UnusedForeachFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedForeachVariables',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedForeachVariables', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -1134,11 +1014,7 @@ class VariableAnalysisTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('AssignmentByReferenceFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'ignoreUnusedRegexp',
-			'/^varX$/'
-		);
+		$this->setSniffProperty($phpcsFile, 'ignoreUnusedRegexp', '/^varX$/');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [

--- a/Tests/VariableAnalysisSniff/VariableArgumentListTest.php
+++ b/Tests/VariableAnalysisSniff/VariableArgumentListTest.php
@@ -10,11 +10,7 @@ class VariableArgumentListTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('VariableArgumentListFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'true'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'true');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [
@@ -31,11 +27,7 @@ class VariableArgumentListTest extends BaseTestCase
 	{
 		$fixtureFile = $this->getFixture('VariableArgumentListFixture.php');
 		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
-		$phpcsFile->ruleset->setSniffProperty(
-			'VariableAnalysis\Sniffs\CodeAnalysis\VariableAnalysisSniff',
-			'allowUnusedParametersBeforeUsed',
-			'false'
-		);
+		$this->setSniffProperty($phpcsFile, 'allowUnusedParametersBeforeUsed', 'false');
 		$phpcsFile->process();
 		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedWarnings = [


### PR DESCRIPTION
As per the deprecation notice being thrown:
> `setSniffProperty: the format of the $settings parameter has changed from (mixed) $value to array('scope' => 'sniff|standard', 'value' => $value). Please update your integration code. See PR #3629 for more information.`

... the format of the `$settings` parameter for the `Ruleset::setSniffProperty()` method has changed to allow PHPCS to prevent notices about dynamic properties.

This commit updates the test suite to allow for both the PHPCS < 3.8.0 as well as the PHPCS 3.8.0+ way of setting properties directly on the Ruleset by adding a helper method to the `BaseTestCase` to set the properties in the correct way depending on the PHPCS version used.

Ref: squizlabs/php_codesniffer#3629