### PR TITLE
Do not close scope of ref reassignment when inside else

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AssignmentByReferenceFixture.php
@@ -55,7 +55,7 @@ function doubleUsedThenUsedAssignmentByReference() {
   return $var;
 }
 
-function somefunc($choice, &$arr1, &$arr_default) {
+function somefunc1($choice, &$arr1, &$arr_default) {
   $var = &$arr_default;
 
   if ($choice) {
@@ -65,10 +65,20 @@ function somefunc($choice, &$arr1, &$arr_default) {
   echo $var;
 }
 
-function somefunc($choice, &$arr1, &$arr_default) {
+function somefunc2($choice, &$arr1, &$arr_default) {
   if ($choice) {
     $var = &$arr_default; // unused variable $var
     $var = &$arr1;
     echo $var;
   }
+}
+
+function assignByRef2($field_id, $form) {
+  $wrapper_id = $field_id . '_wrapper';
+  if (!isset($form[$field_id]) && isset($form[$wrapper_id])) {
+    $element = &$form[$wrapper_id][$field_id];
+  } else {
+    $element = &$form[$field_id];
+  }
+  $element['test'] = 'test';
 }

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -128,21 +128,26 @@ class Helpers
 	}
 
 	/**
-	 * Return true if the token conditions are within an if block before they are
-	 * within a class or function.
+	 * Return true if the token conditions are within an IF/ELSE/ELSEIF block
+	 * before they are within a class or function.
 	 *
 	 * @param (int|string)[] $conditions
 	 *
 	 * @return int|string|null
 	 */
-	public static function getClosestIfPositionIfBeforeOtherConditions(array $conditions)
+	public static function getClosestConditionPositionIfBeforeOtherConditions(array $conditions)
 	{
 		$conditionsInsideOut = array_reverse($conditions, true);
 		if (empty($conditions)) {
 			return null;
 		}
 		$scopeCode = reset($conditionsInsideOut);
-		if ($scopeCode === T_IF) {
+		$conditionalCodes = [
+			T_IF,
+			T_ELSE,
+			T_ELSEIF,
+		];
+		if (in_array($scopeCode, $conditionalCodes, true)) {
 			return key($conditionsInsideOut);
 		}
 		return null;

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -928,6 +928,9 @@ class Helpers
 	 */
 	public static function splitStringToArray($pattern, $value)
 	{
+		if (empty($pattern)) {
+			return [];
+		}
 		$result = preg_split($pattern, $value);
 		return is_array($result) ? $result : [];
 	}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1154,17 +1154,18 @@ class VariableAnalysisSniff implements Sniff
 			// are inside a conditional block because in that case the condition may
 			// never activate.
 			$scopeInfo = $this->getOrCreateScopeInfo($currScope);
-			$ifPtr = Helpers::getClosestIfPositionIfBeforeOtherConditions($tokens[$referencePtr]['conditions']);
+			$conditionPointer = Helpers::getClosestConditionPositionIfBeforeOtherConditions($tokens[$referencePtr]['conditions']);
 			$lastAssignmentPtr = $varInfo->firstDeclared;
-			if (! $ifPtr && $lastAssignmentPtr) {
+			if (! $conditionPointer && $lastAssignmentPtr) {
 				Helpers::debug("processVariableAsAssignment: considering close of scope for '{$varName}' due to reference reassignment");
 				$this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
 			}
-			if ($ifPtr && $lastAssignmentPtr && $ifPtr < $lastAssignmentPtr) {
-				Helpers::debug("processVariableAsAssignment: considering close of scope for '{$varName}' due to reference reassignment ignoring recent IF");
+			if ($conditionPointer && $lastAssignmentPtr && $conditionPointer < $lastAssignmentPtr) {
+				// We may be inside a condition but the last assignment was also inside this condition.
+				Helpers::debug("processVariableAsAssignment: considering close of scope for '{$varName}' due to reference reassignment ignoring recent condition");
 				$this->processScopeCloseForVariable($phpcsFile, $varInfo, $scopeInfo);
 			}
-			if ($ifPtr && $lastAssignmentPtr && $ifPtr > $lastAssignmentPtr) {
+			if ($conditionPointer && $lastAssignmentPtr && $conditionPointer > $lastAssignmentPtr) {
 				Helpers::debug("processVariableAsAssignment: not considering close of scope for '{$varName}' due to reference reassignment because it is conditional");
 			}
 			// The referenced variable may have a different name, but we don't

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -460,7 +460,7 @@ class VariableAnalysisSniff implements Sniff
 		if (in_array($varName, $validUnusedVariableNames)) {
 			$scopeInfo->variables[$varName]->ignoreUnused = true;
 		}
-		if (isset($this->ignoreUnusedRegexp) && preg_match($this->ignoreUnusedRegexp, $varName) === 1) {
+		if (! empty($this->ignoreUnusedRegexp) && preg_match($this->ignoreUnusedRegexp, $varName) === 1) {
 			$scopeInfo->variables[$varName]->ignoreUnused = true;
 		}
 		if ($scopeInfo->scopeStartIndex === 0 && $this->allowUndefinedVariablesInFileScope) {
@@ -469,7 +469,7 @@ class VariableAnalysisSniff implements Sniff
 		if (in_array($varName, $validUndefinedVariableNames)) {
 			$scopeInfo->variables[$varName]->ignoreUndefined = true;
 		}
-		if (isset($this->validUndefinedVariableRegexp) && preg_match($this->validUndefinedVariableRegexp, $varName) === 1) {
+		if (! empty($this->validUndefinedVariableRegexp) && preg_match($this->validUndefinedVariableRegexp, $varName) === 1) {
 			$scopeInfo->variables[$varName]->ignoreUndefined = true;
 		}
 		Helpers::debug("getOrCreateVariableInfo: scope for '{$varName}' is now", $scopeInfo);
@@ -1850,7 +1850,8 @@ class VariableAnalysisSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[$stackPtr];
 
-		if (!preg_match_all(Constants::getDoubleQuotedVarRegexp(), $token['content'], $matches)) {
+		$regexp = Constants::getDoubleQuotedVarRegexp();
+		if (! empty($regexp) && !preg_match_all($regexp, $token['content'], $matches)) {
 			return;
 		}
 		Helpers::debug('examining token for variable in string', $token);
@@ -1923,7 +1924,8 @@ class VariableAnalysisSniff implements Sniff
 			}
 			if ($argumentFirstToken['code'] === T_DOUBLE_QUOTED_STRING) {
 				// Double-quoted string literal.
-				if (preg_match(Constants::getDoubleQuotedVarRegexp(), $argumentFirstToken['content'])) {
+				$regexp = Constants::getDoubleQuotedVarRegexp();
+				if (! empty($regexp) && preg_match($regexp, $argumentFirstToken['content'])) {
 					// Bail if the string needs variable expansion, that's runtime stuff.
 					continue;
 				}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1852,10 +1852,15 @@ class VariableAnalysisSniff implements Sniff
 
 		$regexp = Constants::getDoubleQuotedVarRegexp();
 		if (! empty($regexp) && !preg_match_all($regexp, $token['content'], $matches)) {
+			Helpers::debug('processVariableInString: no variables found', $token);
 			return;
 		}
 		Helpers::debug('examining token for variable in string', $token);
 
+		if (empty($matches)) {
+			Helpers::debug('processVariableInString: no variables found after search', $token);
+			return;
+		}
 		foreach ($matches[1] as $varName) {
 			$varName = Helpers::normalizeVarName($varName);
 


### PR DESCRIPTION
When we reassign a reference variable, we need to know if it has been used first. This is because changing the reference of a variable is like creating a new variable; if its previous value was never used, then we should report an unused variable.

For example, this is the intended behavior:

```php
$foo = &$bar;  // Warning that $foo is unused because once it is reassigned, it is a different variable.
$foo = &$yaz;
echo $foo;
```

However, because conditional statements might or might not be run, we must assume that assignments by reference might not happen and should not trigger a warning even if it appears they are unused.

This example reassignment should not trigger a warning:

```php
$foo = &$bar; // No warning because we cannot be sure that the next assignment will happen.
if ( $x ) {
  $foo = &$yaz;
}
echo $foo;
```

This logic already exists, but before this PR it does not apply to `else` blocks or `elseif` blocks, only `if`.

For example, this code should not trigger a warning, but it does before this PR:

```php
if ( $x ) {
  $foo = &$bar; // No warning because we cannot be sure that the 'else' assignment will happen.
} else {
  $foo = &$yaz;
}
echo $foo;
```

In this PR we extend that logic to also cover `else` and `elseif`.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/305