### PR TITLE
Make sure that recursive search of list assignments stays inside them

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/DestructuringFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/DestructuringFixture.php
@@ -48,3 +48,13 @@ function function_with_nested_destructure_using_short_list() {
     echo $foo;
     echo $bar;
 }
+
+function function_with_short_destructuring_assignment_and_array_arg(int $baz) {
+	[$bar] = doSomething([$baz]);
+	return $bar;
+}
+
+function function_with_destructuring_assignment_and_array_arg(int $baz) {
+	list($bar) = doSomething([$baz]);
+	return $bar;
+}


### PR DESCRIPTION
When determining if a variable inside a square bracket is a shorthand list assignment, we cannot rely on the tokenizer's `nested_parenthesis` to tell us if we are inside a nested assignment (like `[ $foo, [ $bar ] ] = [ 'foo', [ 'bar'  ]  ]`); we must instead search for the nested bracket manually. To do this, the sniff searched for the nearest opening bracket within the same statement. However, it did not then check to make sure that bracket's closing token was _outside_ of the position of the token we are searching for. This meant that a statement like `[$foo] = something([$bar])` would treat `$bar` as being inside the brackets that surround `$foo` and therefore that both are inside a list assignment.

In this PR we alter the code that searches for the opening bracket to also check the position of the closing bracket.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/317