### PR TITLE
Fix nullable constructor promotion detection

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -194,6 +194,8 @@ class VariableAnalysisTest extends BaseTestCase
 			115,
 			116,
 			174,
+			202,
+			203,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ClassWithMembersFixture.php
@@ -195,3 +195,30 @@ class ClassWithReadonlyConstructorPromotion {
     return $this->message;
   }
 }
+
+class ClassWithNullableConstructorPromotion {
+  public function __construct(
+        public ?string $name = 'Brent',
+        $unused, // Unused variable $unused
+        ?string $unused2, // Unused variable $unused2
+        public ?string $role,
+        private ?string $role2,
+        protected ?string $role3,
+        public $nickname,
+        private $nickname2,
+        protected $nickname3
+  ) {
+  }
+}
+
+class ClassWithReadonlyNullableConstructorPromotion {
+  public function __construct(
+    private readonly ?string $message,
+    private readonly $name,
+    public readonly ?bool $key
+  ) {}
+
+  public function getMessage(): string {
+    return $this->message;
+  }
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -1561,6 +1561,15 @@ class Helpers
 			return false;
 		}
 		$prev2Token = $tokens[$prev2Index];
+		// If the token that might be a visibility keyword is a nullable typehint,
+		// ignore it and move back one token further eg: `public ?boolean $foobar`.
+		if ($prev2Token['code'] === 'PHPCS_T_NULLABLE') {
+			$prev2Index = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev2Index - 1), $functionIndex, true);
+			if (! is_int($prev2Index)) {
+				return false;
+			}
+		}
+		$prev2Token = $tokens[$prev2Index];
 		if (in_array($prev2Token['code'], Tokens::$scopeModifiers, true)) {
 			return true;
 		}


### PR DESCRIPTION
When trying to detect variables that are constructor promotion (see https://github.com/sirbrillig/phpcs-variable-analysis/pull/266 and https://github.com/sirbrillig/phpcs-variable-analysis/pull/294) we might also have variables that have nullable types. These variables were not being correctly identified as constructor promotion because the token we were examining to see if it was `public`/`private`/`protected` was actually not far enough back and we were instead looking at the `?`.

In this diff, we check for and ignore nullable tokens when looking for constructor promotion.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/320