### PR TITLE
test: add test for nested arrow functions

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -166,3 +166,8 @@ function arrowFunctionWithQuotes($allowedReferrers) {
     && $permissionName !== CustomPermission::ALL_CONFIG
   );
 }
+
+function arrowFunctionNestedAsExpressionWithNoWarnings() {
+    $ids = fn($posts) => array_map(fn($post) => $post->id, $posts);
+    echo $ids([]);
+}


### PR DESCRIPTION
This adds a test for a nested arrow function case that shouldn't show a warning.