### PR TITLE
Composer: psalm 5 is out of beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1",
         "phpstan/phpstan": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
-        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
     }
 }


### PR DESCRIPTION
Psalm 5 has been out of beta for quite a while now (November 2022), so let's remove the `@beta`.