### PR TITLE
Support nested arrow functions

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -166,3 +166,12 @@ function arrowFunctionWithQuotes($allowedReferrers) {
     && $permissionName !== CustomPermission::ALL_CONFIG
   );
 }
+
+function arrowFunctionWithNestedArrowFunction() {
+	$fn = fn($outerArrowArg) => [
+    $outerArrowArg,
+    fn($insideArg) => $insideArg,
+    $outerArrowArg,
+	];
+	$fn();
+}


### PR DESCRIPTION
The way I find the scope opener for an arrow function is by searching backwards for a `fn` token from the place a variable is used if that variable might be within an arrow function. However, if there's another nested arrow function before the actual scope opener we want, this will result in a false positive and report the incorrect scope.

In this PR, we add a condition to the algorithm which searches backwards for the `fn` token: if it finds an arrow function scope _close_ token before it finds a scope opener, then we move back to the start of that scope before continuing to search backwards.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/329