### PR TITLE
Simplify detecting class properties to improve detection for anonymous classes

### DIFF
--- a/Tests/VariableAnalysisSniff/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -44,7 +44,7 @@ $anonClass = new class() { // should trigger unused warning
 
 class ClassWithAnonymousClassAndTypeHints
 {
-		int $main_id = 1;
+		readonly int $main_id;
 		public int $id = 1;
 		public \My\Data|bool $data;
 
@@ -52,7 +52,7 @@ class ClassWithAnonymousClassAndTypeHints
 		{
 				return new class
 				{
-						int $main_id = 1;
+						readonly int $main_id;
 						public int $id = 123456;
 						public \My\Data|bool $data;
 				};

--- a/Tests/VariableAnalysisSniff/fixtures/AnonymousClassWithPropertiesFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/AnonymousClassWithPropertiesFixture.php
@@ -41,3 +41,28 @@ $anonClass = new class() { // should trigger unused warning
         echo static::$storedHello;
     }
 };
+
+class ClassWithAnonymousClassAndTypeHints
+{
+		int $main_id = 1;
+		public int $id = 1;
+		public \My\Data|bool $data;
+
+		public function test_1(): object
+		{
+				return new class
+				{
+						int $main_id = 1;
+						public int $id = 123456;
+						public \My\Data|bool $data;
+				};
+		}
+
+		public function test_2(): object
+		{
+				return new class
+				{
+						public $id = 123456;
+				};
+		}
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -864,29 +864,7 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	protected function processVariableAsClassProperty(File $phpcsFile, $stackPtr)
 	{
-		$propertyDeclarationKeywords = [
-			T_PUBLIC,
-			T_PRIVATE,
-			T_PROTECTED,
-			T_VAR,
-		];
-		$stopAtPtr = $stackPtr - 2;
-		$visibilityPtr = $phpcsFile->findPrevious($propertyDeclarationKeywords, $stackPtr - 1, $stopAtPtr > 0 ? $stopAtPtr : 0);
-		if ($visibilityPtr) {
-			return true;
-		}
-		$staticPtr = $phpcsFile->findPrevious(T_STATIC, $stackPtr - 1, $stopAtPtr > 0 ? $stopAtPtr : 0);
-		if (! $staticPtr) {
-			return false;
-		}
-		$stopAtPtr = $staticPtr - 2;
-		$visibilityPtr = $phpcsFile->findPrevious($propertyDeclarationKeywords, $staticPtr - 1, $stopAtPtr > 0 ? $stopAtPtr : 0);
-		if ($visibilityPtr) {
-			return true;
-		}
-		// it's legal to use `static` to define properties as well as to
-		// define variables, so make sure we are not in a function before
-		// assuming it's a property.
+		// Make sure we are not in a class method before assuming it's a property.
 		$tokens = $phpcsFile->getTokens();
 
 		/** @var array{conditions?: (int|string)[], content?: string}|null */


### PR DESCRIPTION
Currently this sniff allows class properties to be unused without a warning. To determine if a variable it finds is a class property, it performs several checks; first it looks for a visibility keyword (eg: `public`) as the previous token. If that exists, then we assume it is a property. If that isn't found, it looks for a `static` keyword preceded by a visibility keyword. If there is no `static`, then it assumes there is no property access. If there _is_ a `static`, we repeat the check for the visibility keyword. If there is a `static` token but no visibility keyword, we instead look to see if we are inside a class definition but not inside a function. If that is true, then we are a class property.

This logic is causing some problems for typed properties inside anonymous classes because the type keyword(s) are interfering with finding the visibility keyword. We can fix this by looking more carefully for the visibility keyword, like so:

```php
		$startOfStatement = $phpcsFile->findPrevious([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $stackPtr - 1);
		$stopAtPtr = is_bool($startOfStatement) ? 1 : $startOfStatement;
		$visibilityPtr = $phpcsFile->findPrevious($propertyDeclarationKeywords, $stackPtr - 1, $stopAtPtr > 0 ? $stopAtPtr : 0);
```

But that doesn't totally solve the problem for anonymous classes and I realized that we probably don't need to do it anyway. The last check that looks to see if we are inside a class definition but outside a function should be enough to find any property. 

This PR removes all the logic described above and leaves only the final check.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/332