### PR TITLE
Run static-analysis Github action on PHP 8.1

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 'latest'
+          php-version: "8.1"
           coverage: none
 
       # Install dependencies and handle caching in one go.


### PR DESCRIPTION
Because there is a dependency conflict between phpunit and psalm (psalm does not support later versions of the php parser – see https://github.com/vimeo/psalm/issues/11112), we cannot run psalm on PHP versions where the conflict forces the `nikic/php-parser` dependency to be < 1.0. In this PR we force running `psalm` under PHP 8.1.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/335
