### PR TITLE
Handle compact inside arrow functions

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -522,6 +522,8 @@ class VariableAnalysisTest extends BaseTestCase
 			23,
 			26,
 			36,
+			41,
+			42,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -543,6 +545,8 @@ class VariableAnalysisTest extends BaseTestCase
 		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[26][66][0]['source']);
 		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[36][5][0]['source']);
 		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[36][23][0]['source']);
+		$this->assertSame(self::UNUSED_ERROR_CODE, $warnings[41][22][0]['source']);
+		$this->assertSame(self::UNDEFINED_ERROR_CODE, $warnings[42][39][0]['source']);
 	}
 
 	public function testTraitAllowsThis()

--- a/Tests/VariableAnalysisSniff/fixtures/CompactFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/CompactFixture.php
@@ -39,10 +39,13 @@ function foo() {
 function function_with_arrow_function_and_compact() {
 	$make_array = fn ($arg) => compact('arg');
 	$make_nothing = fn ($arg) => []; // Unused variable $arg
-	$make_no_variable = fn () => compact('arg') // Undefined variable $arg
+	$make_no_variable = fn () => compact('arg');
 	echo $make_array('hello');
 	echo $make_nothing('hello');
 	echo $make_no_variable();
 	$make_array_multiple = fn ($arg1, $arg2, $arg3) => compact('arg1', 'arg2', 'arg3');
 	echo $make_array_multiple();
+	$outside_var = 'hello world';
+	$use_outside_var = fn($inside_var) => compact('outside_var', 'inside_var');
+	echo $use_outside_var();
 }

--- a/Tests/VariableAnalysisSniff/fixtures/CompactFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/CompactFixture.php
@@ -35,3 +35,14 @@ function foo() {
     $a = 'Hello';
     $c = compact( $a, $b ); // Unused variable c and undefined variable b
 }
+
+function function_with_arrow_function_and_compact() {
+	$make_array = fn ($arg) => compact('arg');
+	$make_nothing = fn ($arg) => []; // Unused variable $arg
+	$make_no_variable = fn () => compact('arg') // Undefined variable $arg
+	echo $make_array('hello');
+	echo $make_nothing('hello');
+	echo $make_no_variable();
+	$make_array_multiple = fn ($arg1, $arg2, $arg3) => compact('arg1', 'arg2', 'arg3');
+	echo $make_array_multiple();
+}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -4,6 +4,7 @@ namespace VariableAnalysis\Lib;
 
 use PHP_CodeSniffer\Files\File;
 use VariableAnalysis\Lib\ScopeInfo;
+use VariableAnalysis\Lib\Constants;
 use VariableAnalysis\Lib\ForLoopInfo;
 use VariableAnalysis\Lib\EnumInfo;
 use VariableAnalysis\Lib\ScopeType;
@@ -472,7 +473,7 @@ class Helpers
 			$argumentFirstToken = $tokens[$argumentPtrs[0]];
 			if ($argumentFirstToken['code'] === T_ARRAY) {
 				// It's an array argument, recurse.
-				$arrayArguments = Helpers::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
+				$arrayArguments = self::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
 				$variablePositionsAndNames = array_merge($variablePositionsAndNames, self::getVariablesInsideCompact($phpcsFile, $stackPtr, $arrayArguments));
 				continue;
 			}

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -446,18 +446,18 @@ class Helpers
 	}
 
 	/**
-	 * Return the variable names of each variable targetted by a `compact()` call.
+	 * Return the variable names and positions of each variable targetted by a `compact()` call.
 	 *
 	 * @param File                   $phpcsFile
 	 * @param int                    $stackPtr
 	 * @param array<int, array<int>> $arguments The stack pointers of each argument; see findFunctionCallArguments
 	 *
-	 * @return string[]
+	 * @return array<VariableInfo> each variable's firstRead position and its name; other VariableInfo properties are not set!
 	 */
-	public static function getVariableNamesFromCompact(File $phpcsFile, $stackPtr, $arguments)
+	public static function getVariablesInsideCompact(File $phpcsFile, $stackPtr, $arguments)
 	{
 		$tokens = $phpcsFile->getTokens();
-		$variableNames = [];
+		$variablePositionsAndNames = [];
 
 		foreach ($arguments as $argumentPtrs) {
 			$argumentPtrs = array_values(array_filter($argumentPtrs, function ($argumentPtr) use ($tokens) {
@@ -473,7 +473,7 @@ class Helpers
 			if ($argumentFirstToken['code'] === T_ARRAY) {
 				// It's an array argument, recurse.
 				$arrayArguments = Helpers::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
-				$variableNames = array_merge($variableNames, self::getVariableNamesFromCompact($phpcsFile, $stackPtr, $arrayArguments));
+				$variablePositionsAndNames = array_merge($variablePositionsAndNames, self::getVariablesInsideCompact($phpcsFile, $stackPtr, $arrayArguments));
 				continue;
 			}
 			if (count($argumentPtrs) > 1) {
@@ -484,7 +484,9 @@ class Helpers
 				// Single-quoted string literal, ie compact('whatever').
 				// Substr is to strip the enclosing single-quotes.
 				$varName = substr($argumentFirstToken['content'], 1, -1);
-				$variableNames[] = $varName;
+				$variable = new VariableInfo($varName);
+				$variable->firstRead = $argumentPtrs[0];
+				$variablePositionsAndNames[] = $variable;
 				continue;
 			}
 			if ($argumentFirstToken['code'] === T_DOUBLE_QUOTED_STRING) {
@@ -496,11 +498,13 @@ class Helpers
 				}
 				// Substr is to strip the enclosing double-quotes.
 				$varName = substr($argumentFirstToken['content'], 1, -1);
-				$variableNames[] = $varName;
+				$variable = new VariableInfo($varName);
+				$variable->firstRead = $argumentPtrs[0];
+				$variablePositionsAndNames[] = $variable;
 				continue;
 			}
 		}
-		return $variableNames;
+		return $variablePositionsAndNames;
 	}
 
 	/**

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -446,6 +446,64 @@ class Helpers
 	}
 
 	/**
+	 * Return the variable names of each variable targetted by a `compact()` call.
+	 *
+	 * @param File                   $phpcsFile
+	 * @param int                    $stackPtr
+	 * @param array<int, array<int>> $arguments The stack pointers of each argument; see findFunctionCallArguments
+	 *
+	 * @return string[]
+	 */
+	public static function getVariableNamesFromCompact(File $phpcsFile, $stackPtr, $arguments)
+	{
+		$tokens = $phpcsFile->getTokens();
+		$variableNames = [];
+
+		foreach ($arguments as $argumentPtrs) {
+			$argumentPtrs = array_values(array_filter($argumentPtrs, function ($argumentPtr) use ($tokens) {
+				return isset(Tokens::$emptyTokens[$tokens[$argumentPtr]['code']]) === false;
+			}));
+			if (empty($argumentPtrs)) {
+				continue;
+			}
+			if (!isset($tokens[$argumentPtrs[0]])) {
+				continue;
+			}
+			$argumentFirstToken = $tokens[$argumentPtrs[0]];
+			if ($argumentFirstToken['code'] === T_ARRAY) {
+				// It's an array argument, recurse.
+				$arrayArguments = Helpers::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
+				$variableNames = array_merge($variableNames, self::getVariableNamesFromCompact($phpcsFile, $stackPtr, $arrayArguments));
+				continue;
+			}
+			if (count($argumentPtrs) > 1) {
+				// Complex argument, we can't handle it, ignore.
+				continue;
+			}
+			if ($argumentFirstToken['code'] === T_CONSTANT_ENCAPSED_STRING) {
+				// Single-quoted string literal, ie compact('whatever').
+				// Substr is to strip the enclosing single-quotes.
+				$varName = substr($argumentFirstToken['content'], 1, -1);
+				$variableNames[] = $varName;
+				continue;
+			}
+			if ($argumentFirstToken['code'] === T_DOUBLE_QUOTED_STRING) {
+				// Double-quoted string literal.
+				$regexp = Constants::getDoubleQuotedVarRegexp();
+				if (! empty($regexp) && preg_match($regexp, $argumentFirstToken['content'])) {
+					// Bail if the string needs variable expansion, that's runtime stuff.
+					continue;
+				}
+				// Substr is to strip the enclosing double-quotes.
+				$varName = substr($argumentFirstToken['content'], 1, -1);
+				$variableNames[] = $varName;
+				continue;
+			}
+		}
+		return $variableNames;
+	}
+
+	/**
 	 * Return the token index of the scope start for a token
 	 *
 	 * For a variable within a function body, or a variable within a function

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1882,7 +1882,7 @@ class VariableAnalysisSniff implements Sniff
 		Helpers::debug("processCompact at {$stackPtr}");
 		$arguments = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);
 		$variables = Helpers::getVariablesInsideCompact($phpcsFile, $stackPtr, $arguments);
-		foreach ( $variables as $variable ) {
+		foreach ($variables as $variable) {
 			$currScope = Helpers::findVariableScope($phpcsFile, $stackPtr, $variable->name);
 			if ($currScope === null) {
 				continue;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1870,61 +1870,6 @@ class VariableAnalysisSniff implements Sniff
 	}
 
 	/**
-	 * @param File                   $phpcsFile
-	 * @param int                    $stackPtr
-	 * @param array<int, array<int>> $arguments The stack pointers of each argument
-	 * @param int                    $currScope
-	 *
-	 * @return void
-	 */
-	protected function processCompactArguments(File $phpcsFile, $stackPtr, $arguments, $currScope)
-	{
-		$tokens = $phpcsFile->getTokens();
-
-		foreach ($arguments as $argumentPtrs) {
-			$argumentPtrs = array_values(array_filter($argumentPtrs, function ($argumentPtr) use ($tokens) {
-				return isset(Tokens::$emptyTokens[$tokens[$argumentPtr]['code']]) === false;
-			}));
-			if (empty($argumentPtrs)) {
-				continue;
-			}
-			if (!isset($tokens[$argumentPtrs[0]])) {
-				continue;
-			}
-			$argumentFirstToken = $tokens[$argumentPtrs[0]];
-			if ($argumentFirstToken['code'] === T_ARRAY) {
-				// It's an array argument, recurse.
-				$arrayArguments = Helpers::findFunctionCallArguments($phpcsFile, $argumentPtrs[0]);
-				$this->processCompactArguments($phpcsFile, $stackPtr, $arrayArguments, $currScope);
-				continue;
-			}
-			if (count($argumentPtrs) > 1) {
-				// Complex argument, we can't handle it, ignore.
-				continue;
-			}
-			if ($argumentFirstToken['code'] === T_CONSTANT_ENCAPSED_STRING) {
-				// Single-quoted string literal, ie compact('whatever').
-				// Substr is to strip the enclosing single-quotes.
-				$varName = substr($argumentFirstToken['content'], 1, -1);
-				$this->markVariableReadAndWarnIfUndefined($phpcsFile, $varName, $argumentPtrs[0], $currScope);
-				continue;
-			}
-			if ($argumentFirstToken['code'] === T_DOUBLE_QUOTED_STRING) {
-				// Double-quoted string literal.
-				$regexp = Constants::getDoubleQuotedVarRegexp();
-				if (! empty($regexp) && preg_match($regexp, $argumentFirstToken['content'])) {
-					// Bail if the string needs variable expansion, that's runtime stuff.
-					continue;
-				}
-				// Substr is to strip the enclosing double-quotes.
-				$varName = substr($argumentFirstToken['content'], 1, -1);
-				$this->markVariableReadAndWarnIfUndefined($phpcsFile, $varName, $argumentPtrs[0], $currScope);
-				continue;
-			}
-		}
-	}
-
-	/**
 	 * Called to process variables named in a call to compact().
 	 *
 	 * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
@@ -1934,13 +1879,18 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	protected function processCompact(File $phpcsFile, $stackPtr)
 	{
-		$currScope = Helpers::findVariableScope($phpcsFile, $stackPtr);
-		if ($currScope === null) {
-			return;
-		}
+		Helpers::debug("processCompact at {$stackPtr}");
 
 		$arguments = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);
-		$this->processCompactArguments($phpcsFile, $stackPtr, $arguments, $currScope);
+		$variableNames = Helpers::getVariableNamesFromCompact($phpcsFile, $stackPtr, $arguments);
+
+		foreach ( $variableNames as $variableName ) {
+			$currScope = Helpers::findVariableScope($phpcsFile, $stackPtr, $variableName);
+			if ($currScope === null) {
+				continue;
+			}
+			$this->markVariableReadAndWarnIfUndefined($phpcsFile, $variableName, $stackPtr, $currScope);
+		}
 	}
 
 	/**

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1880,16 +1880,14 @@ class VariableAnalysisSniff implements Sniff
 	protected function processCompact(File $phpcsFile, $stackPtr)
 	{
 		Helpers::debug("processCompact at {$stackPtr}");
-
 		$arguments = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);
-		$variableNames = Helpers::getVariableNamesFromCompact($phpcsFile, $stackPtr, $arguments);
-
-		foreach ( $variableNames as $variableName ) {
-			$currScope = Helpers::findVariableScope($phpcsFile, $stackPtr, $variableName);
+		$variables = Helpers::getVariablesInsideCompact($phpcsFile, $stackPtr, $arguments);
+		foreach ( $variables as $variable ) {
+			$currScope = Helpers::findVariableScope($phpcsFile, $stackPtr, $variable->name);
 			if ($currScope === null) {
 				continue;
 			}
-			$this->markVariableReadAndWarnIfUndefined($phpcsFile, $variableName, $stackPtr, $currScope);
+			$this->markVariableReadAndWarnIfUndefined($phpcsFile, $variable->name, $variable->firstRead, $currScope);
 		}
 	}
 

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1887,7 +1887,8 @@ class VariableAnalysisSniff implements Sniff
 			if ($currScope === null) {
 				continue;
 			}
-			$this->markVariableReadAndWarnIfUndefined($phpcsFile, $variable->name, $variable->firstRead, $currScope);
+			$variablePosition = $variable->firstRead ? $variable->firstRead : $stackPtr;
+			$this->markVariableReadAndWarnIfUndefined($phpcsFile, $variable->name, $variablePosition, $currScope);
 		}
 	}
 


### PR DESCRIPTION
The code to detect and process variables inside calls to `compact()` (please, stop using that function 😩) was finding and processing those variables all at once, using the scope of the `compact` token itself as if it were a variable. However, this does not work for `compact` used inside arrow functions because there are multiple possible scopes for each variable.

In this PR, we refactor the code to process each variable inside `compact()` separately, allowing us to determine each one's scope before determining if it is defined.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/330