### PR TITLE
Improve phpstan configuration

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,6 @@
 parameters:
   level: 7
-  reportUnmatchedIgnoredErrors: false
   bootstrapFiles:
-    - %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
+    - vendor/squizlabs/php_codesniffer/autoload.php
   paths:
-    - %currentWorkingDirectory%/VariableAnalysis/
-  excludePaths:
-    - %currentWorkingDirectory%/Tests/
-  ignoreErrors:
-    - '~^Constant T_\w+ not found.$~'
+    - VariableAnalysis/


### PR DESCRIPTION
- currentWorkingDirectory is the default
- excluding a not included path is useless
- that ignored error does not occur anymore
- `reportUnmatchedIgnoredErrors` is not safe (may hide problems)
