### PR TITLE
Add perf-guard github workflow

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,5 +140,5 @@ jobs:
         run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"
 
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
+        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.2 }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAX_PHPCS_PERF_SECS: 0.6
+      MAX_PHPCS_PERF_SECS: 0.2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,17 +140,13 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          echo "PHPCS_PERF_REPORT=${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
-
-      - name: Parse performance report
-        id: parse_performance_report
-        run: |
-          TOTAL_SECS=$(echo ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          echo "-----"
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 
       # fromJSON is used to convert strings to numbers in github actions.
       # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.parse_performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
+        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -147,7 +147,11 @@ jobs:
       - name: Parse performance report
         id: parse_performance_report
         run: |
-          TOTAL_SECS=$(echo ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          PHPCS_OUTPUT=$(cat <<-EOF
+          ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}
+          EOF
+          )"
+          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Run performance report
         id: performance_report
-        run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')" >> $GITHUB_OUTPUT
+        run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')" >> $GITHUB_OUTPUT
 
       - name: Log performance
         run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          echo "PHPCS_PERF_REPORT=\"${PHPCS_OUTPUT}\"" >> $GITHUB_OUTPUT
+          echo "PHPCS_PERF_REPORT=${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
 
       - name: Parse performance report
         id: parse_performance_report

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -139,6 +139,8 @@ jobs:
       - name: Log performance
         run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"
 
+      # fromJSON is used to convert strings to numbers in github actions.
+      # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
       - name: Compare performance to baseline
         if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -137,5 +137,5 @@ jobs:
         run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')" >> $GITHUB_OUTPUT
 
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.phpunit_version.outputs.PHPCS_PERF_SECS ) > 0.6 }}
+        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -110,6 +110,9 @@ jobs:
     name: "Basic Performance Guard"
     runs-on: ubuntu-latest
 
+    env:
+      MAX_PHPCS_PERF_SECS: 0.6
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -134,13 +137,18 @@ jobs:
 
       - name: Run performance report
         id: performance_report
-        run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')" >> $GITHUB_OUTPUT
-
-      - name: Log performance
-        run: echo "${{ steps.performance_report.outputs.PHPCS_PERF_SECS }}"
+        run: |
+          set -x
+          PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
+          set +x
+          echo "${PHPCS_OUTPUT}"
+          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          echo "-----"
+          echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
+          echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 
       # fromJSON is used to convert strings to numbers in github actions.
       # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
+        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Run performance report
         id: performance_report
         run: |
-          PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.foobar)
+          PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
           echo "${PHPCS_OUTPUT}" > ${{ env.PHPCS_OUTPUT_FILE }}
 

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,5 +140,5 @@ jobs:
         run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"
 
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.2 }}
+        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -138,9 +138,7 @@ jobs:
       - name: Run performance report
         id: performance_report
         run: |
-          set -x
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
-          set +x
           echo "${PHPCS_OUTPUT}"
           TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "-----"

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -137,7 +137,7 @@ jobs:
         run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')" >> $GITHUB_OUTPUT
 
       - name: Log performance
-        run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"
+        run: echo "${{ steps.performance_report.outputs.PHPCS_PERF_SECS }}"
 
       # fromJSON is used to convert strings to numbers in github actions.
       # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,12 +140,12 @@ jobs:
         id: performance_report
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
-          echo "${PHPCS_OUTPUT}" > ${env.PHPCS_OUTPUT_FILE}
+          echo "${PHPCS_OUTPUT}" > ${{ env.PHPCS_OUTPUT_FILE }}
 
       - name: Parse performance report
         id: parse_performance_report
         run: |
-          TOTAL_SECS=$(cat ${env.PHPCS_OUTPUT_FILE} | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          TOTAL_SECS=$(cat ${{ env.PHPCS_OUTPUT_FILE }} | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAX_PHPCS_PERF_SECS: 0.1
+      MAX_PHPCS_PERF_SECS: 0.2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAX_PHPCS_PERF_SECS: 0.6
+      MAX_PHPCS_PERF_SECS: 0.4
 
     steps:
       - name: Checkout code

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,6 +140,7 @@ jobs:
         id: performance_report
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
+          echo "${PHPCS_OUTPUT}"
           echo "${PHPCS_OUTPUT}" > ${{ env.PHPCS_OUTPUT_FILE }}
 
       - name: Parse performance report

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -147,11 +147,7 @@ jobs:
       - name: Parse performance report
         id: parse_performance_report
         run: |
-          PHPCS_OUTPUT=$(cat <<-EOF
-          ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}
-          EOF
-          )"
-          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
+          TOTAL_SECS=$(echo ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          echo "PHPCS_PERF_REPORT=${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
+          echo "PHPCS_PERF_REPORT=\"${PHPCS_OUTPUT}\"" >> $GITHUB_OUTPUT
 
       - name: Parse performance report
         id: parse_performance_report

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -136,6 +136,9 @@ jobs:
         id: performance_report
         run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')" >> $GITHUB_OUTPUT
 
+      - name: Log performance
+        run: echo "${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) }}"
+
       - name: Compare performance to baseline
         if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > 0.6 }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -105,3 +105,35 @@ jobs:
 
       - name: Run Static Analysis
         run: composer static-analysis
+
+  perf-guard:
+    name: "Basic Performance Guard"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          coverage: none
+
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v3"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Download performance test fixture
+        run: wget https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/wp-includes/PHPMailer/PHPMailer.php
+
+      - name: Run performance report
+        run: _PHPCS_RUNTIME=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')
+
+      - name: Compare performance to baseline
+        run: if awk "BEGIN {exit !($_PHPC_RUNTIME > 0.6)}"; then exit 1; fi

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -133,7 +133,9 @@ jobs:
         run: wget https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/wp-includes/PHPMailer/PHPMailer.php
 
       - name: Run performance report
-        run: _PHPCS_RUNTIME=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')
+        id: performance_report
+        run: echo "PHPCS_PERF_SECS=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')" >> $GITHUB_OUTPUT
 
       - name: Compare performance to baseline
-        run: if awk "BEGIN {exit !($_PHPCS_RUNTIME > 0.6)}"; then exit 1; fi
+        if: ${{ fromJSON( steps.phpunit_version.outputs.PHPCS_PERF_SECS ) > 0.6 }}
+        run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAX_PHPCS_PERF_SECS: 0.2
+      MAX_PHPCS_PERF_SECS: 0.1
 
     steps:
       - name: Checkout code

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAX_PHPCS_PERF_SECS: 0.2
+      MAX_PHPCS_PERF_SECS: 0.6
 
     steps:
       - name: Checkout code

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Run performance report
         id: performance_report
         run: |
-          PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
+          PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.foobar)
           echo "${PHPCS_OUTPUT}"
           echo "${PHPCS_OUTPUT}" > ${{ env.PHPCS_OUTPUT_FILE }}
 

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,7 +140,9 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          echo "PHPCS_PERF_REPORT=\"${PHPCS_OUTPUT}\"" >> $GITHUB_OUTPUT
+          echo "PHPCS_PERF_REPORT<<EOF" >> $GITHUB_OUTPUT
+          echo "${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Parse performance report
         id: parse_performance_report

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,13 +140,17 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
-          echo "-----"
+          echo "PHPCS_PERF_REPORT=${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
+
+      - name: Parse performance report
+        id: parse_performance_report
+        run: |
+          TOTAL_SECS=$(echo ${{ steps.performance_report.outputs.PHPCS_PERF_REPORT }}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 
       # fromJSON is used to convert strings to numbers in github actions.
       # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
+        if: ${{ fromJSON( steps.parse_performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -136,4 +136,4 @@ jobs:
         run: _PHPCS_RUNTIME=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php | grep -Eo 'TOTAL RUN TIME[ ]+[0-9.]+'|awk '{ print $4 }')
 
       - name: Compare performance to baseline
-        run: if awk "BEGIN {exit !($_PHPC_RUNTIME > 0.6)}"; then exit 1; fi
+        run: if awk "BEGIN {exit !($_PHPCS_RUNTIME > 0.6)}"; then exit 1; fi

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -112,6 +112,7 @@ jobs:
 
     env:
       MAX_PHPCS_PERF_SECS: 0.4
+      PHPCS_OUTPUT_FILE: "phpcs-report-file"
 
     steps:
       - name: Checkout code
@@ -139,14 +140,17 @@ jobs:
         id: performance_report
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
-          echo "${PHPCS_OUTPUT}"
-          TOTAL_SECS=$(echo ${PHPCS_OUTPUT}| grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
-          echo "-----"
+          echo "${PHPCS_OUTPUT}" > ${env.PHPCS_OUTPUT_FILE}
+
+      - name: Parse performance report
+        id: parse_performance_report
+        run: |
+          TOTAL_SECS=$(cat ${env.PHPCS_OUTPUT_FILE} | grep -Eo 'TOTAL SNIFF PROCESSING TIME[ ]+[0-9.]+'|awk '{ print $5 }')
           echo "Performance time was ${TOTAL_SECS} (max ${{ env.MAX_PHPCS_PERF_SECS }})"
           echo "PHPCS_PERF_SECS=${TOTAL_SECS}" >> $GITHUB_OUTPUT
 
       # fromJSON is used to convert strings to numbers in github actions.
       # @link https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
       - name: Compare performance to baseline
-        if: ${{ fromJSON( steps.performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
+        if: ${{ fromJSON( steps.parse_performance_report.outputs.PHPCS_PERF_SECS ) > fromJSON( env.MAX_PHPCS_PERF_SECS ) }}
         run: exit 1

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -133,7 +133,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Download performance test fixture
-        run: wget https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/wp-includes/PHPMailer/PHPMailer.php
+        run: wget https://raw.githubusercontent.com/PHPMailer/PHPMailer/refs/tags/v6.9.3/src/PHPMailer.php
 
       - name: Run performance report
         id: performance_report

--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -140,9 +140,7 @@ jobs:
         run: |
           PHPCS_OUTPUT=$(./vendor/bin/phpcs --standard=VariableAnalysis --report=Performance ./PHPMailer.php)
           echo "${PHPCS_OUTPUT}"
-          echo "PHPCS_PERF_REPORT<<EOF" >> $GITHUB_OUTPUT
-          echo "${PHPCS_OUTPUT}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "PHPCS_PERF_REPORT=\"${PHPCS_OUTPUT}\"" >> $GITHUB_OUTPUT
 
       - name: Parse performance report
         id: parse_performance_report


### PR DESCRIPTION
This adds a new Github action CI check to make sure that the performance of the sniff does not jump wildly high.

It uses the `PHPMailer.php` file from here: https://raw.githubusercontent.com/PHPMailer/PHPMailer/refs/tags/v6.9.3/src/PHPMailer.php as a test fixture, since that file is relatively large and complex. It then sets a threshold for scanning that file with this sniff. 

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/343