### PR TITLE
Allow finding arrow function variables when arrow function is in file scope

### DIFF
--- a/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
+++ b/Tests/VariableAnalysisSniff/ArrowFunctionTest.php
@@ -58,6 +58,7 @@ class ArrowFunctionTest extends BaseTestCase
 			102,
 			112,
 			150,
+			184,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/ArrowFunctionFixture.php
@@ -175,3 +175,14 @@ function arrowFunctionWithNestedArrowFunction() {
 	];
 	$fn();
 }
+
+// Arrow function in global scope
+array_map(
+	fn(
+		$dir,
+		string $bar,
+		\My\Class|bool $foo, // Unused variable $foo
+		\My\Class|bool $baz,
+	) => PREFIX_DIR . $dir . $bar . $baz,
+	PHP_ERROR_LOGS['ignore_dirs']
+);

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -429,7 +429,8 @@ class Helpers
 		$varName = isset($varName) ? $varName : self::normalizeVarName($token['content']);
 
 		$enclosingScopeIndex = self::findVariableScopeExceptArrowFunctions($phpcsFile, $stackPtr);
-		if ($enclosingScopeIndex) {
+
+		if (!is_null($enclosingScopeIndex)) {
 			$arrowFunctionIndex = self::getContainingArrowFunctionIndex($phpcsFile, $stackPtr, $enclosingScopeIndex);
 			$isTokenInsideArrowFunctionBody = is_int($arrowFunctionIndex);
 			if ($isTokenInsideArrowFunctionBody) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -447,7 +447,7 @@ class Helpers
 			}
 		}
 
-		return self::findVariableScopeExceptArrowFunctions($phpcsFile, $stackPtr);
+		return $enclosingScopeIndex;
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -1,64 +1,63 @@
 {
-    "name": "sirbrillig/phpcs-variable-analysis",
-    "description": "A PHPCS sniff to detect problems with variables.",
-    "type": "phpcodesniffer-standard",
-    "keywords" : [ "phpcs", "static analysis" ],
-    "license": "BSD-2-Clause",
-    "authors": [
-        {
-            "name": "Sam Graham",
-            "email": "php-codesniffer-variableanalysis@illusori.co.uk"
-        },
-        {
-            "name": "Payton Swick",
-            "email": "payton@foolord.com"
-        }
-    ],
-    "support"    : {
-        "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
-        "wiki"  : "https://github.com/sirbrillig/phpcs-variable-analysis/wiki",
-        "source": "https://github.com/sirbrillig/phpcs-variable-analysis"
-    },
-    "config": {
-        "sort-order": true,
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "lock": false
-    },
-    "autoload": {
-        "psr-4": {
-            "VariableAnalysis\\": "VariableAnalysis/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "VariableAnalysis\\Tests\\": "Tests/"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "test": "./vendor/bin/phpunit --no-coverage",
-        "coverage": "./vendor/bin/phpunit",
-        "test-lte9": "./vendor/bin/phpunit -c phpunitlte9.xml.dist --no-coverage",
-        "coverage-lte9": "./vendor/bin/phpunit -c phpunitlte9.xml.dist",
-        "lint": "./vendor/bin/phpcs",
-        "fix": "./vendor/bin/phpcbf",
-        "phpstan": "./vendor/bin/phpstan analyse",
-        "psalm": "./vendor/bin/psalm --no-cache",
-        "static-analysis": "composer phpstan && composer psalm"
-    },
-    "require" : {
-        "php" : ">=5.4.0",
-        "squizlabs/php_codesniffer": "^3.5.6"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
-        "sirbrillig/phpcs-import-detection": "^1.1",
-        "phpcsstandards/phpcsdevcs": "^1.1",
-        "phpstan/phpstan": "^1.7",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
-        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
-    }
+	"name": "sirbrillig/phpcs-variable-analysis",
+	"description": "A PHPCS sniff to detect problems with variables.",
+	"type": "phpcodesniffer-standard",
+	"keywords": ["phpcs", "static analysis"],
+	"license": "BSD-2-Clause",
+	"authors": [
+		{
+			"name": "Sam Graham",
+			"email": "php-codesniffer-variableanalysis@illusori.co.uk"
+		},
+		{
+			"name": "Payton Swick",
+			"email": "payton@foolord.com"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+		"wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki",
+		"source": "https://github.com/sirbrillig/phpcs-variable-analysis"
+	},
+	"config": {
+		"sort-order": true,
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"lock": false
+	},
+	"autoload": {
+		"psr-4": {
+			"VariableAnalysis\\": "VariableAnalysis/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"VariableAnalysis\\Tests\\": "Tests/"
+		}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"scripts": {
+		"test": "./vendor/bin/phpunit --no-coverage",
+		"coverage": "./vendor/bin/phpunit",
+		"test-lte9": "./vendor/bin/phpunit -c phpunitlte9.xml.dist --no-coverage",
+		"coverage-lte9": "./vendor/bin/phpunit -c phpunitlte9.xml.dist",
+		"lint": "./vendor/bin/phpcs",
+		"fix": "./vendor/bin/phpcbf",
+		"phpstan": "./vendor/bin/phpstan analyse",
+		"psalm": "./vendor/bin/psalm --no-cache",
+		"static-analysis": "composer phpstan && composer psalm"
+	},
+	"require": {
+		"php": ">=5.4.0",
+		"squizlabs/php_codesniffer": "^3.5.6"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
+		"phpcsstandards/phpcsdevcs": "^1.1",
+		"phpstan/phpstan": "^1.7",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+		"vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
+	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,7 +30,7 @@
 
     <!--
     #############################################################################
-    USE THE PHPCSDev, ImportDetection and VariableAnalysis RULESETS
+    USE THE PHPCSDev, VariableAnalysis RULESETS
     #############################################################################
     -->
 
@@ -59,7 +59,6 @@
         <exclude name="Generic.Files.LineLength.TooLong" />
     </rule>
 
-    <rule ref="ImportDetection" />
     <rule ref="VariableAnalysis"/>
 
 


### PR DESCRIPTION
Arrow function variables are a little bit tricky to parse because while other variables always exist in one scope or another, variables found within an arrow function could be local to the arrow function or exist in the scope outside the arrow function. 

Therefore, when we find a variable, we first find its largest possible scope – normally this is the function – and then check to see if there is a closer arrow function scope that contains that variable. 

However, there's a bug: if the function scope is not found, we return the file scope (token index 0). There is a guard which does not allow searching for an arrow function scope if the larger scope is falsy. I believe this was meant to guard against a `null` scope, but it was not specific enough and so also was true when it found the file scope 0. As a result, we cannot properly parse function-level variables in arrow functions at the file-level scope.

In this PR, we modify the guard to explicitly check for null.

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/346