### PR TITLE
Accept namespaces in sitePassByRefFunctions

### DIFF
--- a/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
+++ b/Tests/VariableAnalysisSniff/VariableAnalysisTest.php
@@ -298,6 +298,7 @@ class VariableAnalysisTest extends BaseTestCase
 			77,
 			81,
 			98,
+			106,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}
@@ -331,6 +332,36 @@ class VariableAnalysisTest extends BaseTestCase
 		$this->assertSame($expectedWarnings, $lines);
 	}
 
+	public function testFunctionWithReferenceWarningsAllowsCustomFunctionsNamespaced()
+	{
+		$fixtureFile = $this->getFixture('FunctionWithReferenceFixture.php');
+		$phpcsFile = $this->prepareLocalFileForSniffs($fixtureFile);
+		$this->setSniffProperty($phpcsFile, 'sitePassByRefFunctions', '\My\Functions\my_reference_function:2,3 another_reference_function:2,...');
+		$phpcsFile->process();
+		$lines = $this->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedWarnings = [
+			10,
+			11,
+			12,
+			13,
+			14,
+			16,
+			29,
+			41,
+			42,
+			43,
+			46,
+			52,
+			56,
+			57,
+			63,
+			76,
+			81,
+			98,
+		];
+		$this->assertSame($expectedWarnings, $lines);
+	}
+
 	public function testFunctionWithReferenceWarningsAllowsWordPressFunctionsIfSet()
 	{
 		$fixtureFile = $this->getFixture('FunctionWithReferenceFixture.php');
@@ -357,6 +388,7 @@ class VariableAnalysisTest extends BaseTestCase
 			76,
 			77,
 			98,
+			106,
 		];
 		$this->assertSame($expectedWarnings, $lines);
 	}

--- a/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
+++ b/Tests/VariableAnalysisSniff/fixtures/FunctionWithReferenceFixture.php
@@ -100,3 +100,8 @@ function function_with_foreach_with_reference($derivatives, $base_plugin_definit
   }
   return $derivatives;
 }
+
+function function_with_ignored_reference_call_with_namespace() {
+    $foo = 'bar';
+    \My\Functions\my_reference_function($foo, $baz, $bip); // Undefined variable $bar, Undefined variable $bip
+}

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -156,9 +156,9 @@ class VariableAnalysisSniff implements Sniff
 	/**
 	 * A cache for getPassByReferenceFunctions
 	 *
-	 * @var array<array<int|string>>
+	 * @var array<array<int|string>>|null
 	 */
-	private $passByRefFunctionsCache;
+	private $passByRefFunctionsCache = null;
 
 	public function __construct()
 	{
@@ -211,7 +211,7 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	private function getPassByReferenceFunctions()
 	{
-		if (isset($this->passByRefFunctionsCache)) {
+		if (! is_null($this->passByRefFunctionsCache)) {
 			return $this->passByRefFunctionsCache;
 		}
 		$passByRefFunctions = Constants::getPassByReferenceFunctions();

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1507,6 +1507,9 @@ class VariableAnalysisSniff implements Sniff
 		if (! $refArgs) {
 			// Check again with the fully namespaced function name.
 			$functionName = Helpers::getFunctionNameWithNamespace($phpcsFile, $functionPtr);
+			if (! $functionName) {
+				return false;
+			}
 			$refArgs = $this->getPassByReferenceFunction($functionName);
 			if (! $refArgs) {
 				return false;

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -158,7 +158,7 @@ class VariableAnalysisSniff implements Sniff
 	 *
 	 * @var array<array<int|string>>
 	 */
-	private $passByRefFunctionsCache = [];
+	private $passByRefFunctionsCache;
 
 	public function __construct()
 	{
@@ -211,7 +211,7 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	private function getPassByReferenceFunctions()
 	{
-		if ($this->passByRefFunctionsCache) {
+		if (isset($this->passByRefFunctionsCache)) {
 			return $this->passByRefFunctionsCache;
 		}
 		$passByRefFunctions = Constants::getPassByReferenceFunctions();

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -153,6 +153,13 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	public $allowUnusedVariablesBeforeRequire = false;
 
+	/**
+	 * A cache for getPassByReferenceFunctions
+	 *
+	 * @var array<array<int|string>>
+	 */
+	private $passByRefFunctionsCache = [];
+
 	public function __construct()
 	{
 		$this->scopeManager = new ScopeManager();
@@ -195,6 +202,18 @@ class VariableAnalysisSniff implements Sniff
 	 */
 	private function getPassByReferenceFunction($functionName)
 	{
+		$passByRefFunctions = $this->getPassByReferenceFunctions();
+		return isset($passByRefFunctions[$functionName]) ? $passByRefFunctions[$functionName] : [];
+	}
+
+	/**
+	 * @return array<array<int|string>>
+	 */
+	private function getPassByReferenceFunctions()
+	{
+		if ($this->passByRefFunctionsCache) {
+			return $this->passByRefFunctionsCache;
+		}
 		$passByRefFunctions = Constants::getPassByReferenceFunctions();
 		if (!empty($this->sitePassByRefFunctions)) {
 			$lines = Helpers::splitStringToArray('/\s+/', trim($this->sitePassByRefFunctions));
@@ -206,7 +225,8 @@ class VariableAnalysisSniff implements Sniff
 		if ($this->allowWordPressPassByRefFunctions) {
 			$passByRefFunctions = array_merge($passByRefFunctions, Constants::getWordPressPassByReferenceFunctions());
 		}
-		return isset($passByRefFunctions[$functionName]) ? $passByRefFunctions[$functionName] : [];
+		$this->passByRefFunctionsCache = $passByRefFunctions;
+		return $passByRefFunctions;
 	}
 
 	/**
@@ -1485,7 +1505,12 @@ class VariableAnalysisSniff implements Sniff
 		$functionName = $tokens[$functionPtr]['content'];
 		$refArgs = $this->getPassByReferenceFunction($functionName);
 		if (! $refArgs) {
-			return false;
+			// Check again with the fully namespaced function name.
+			$functionName = Helpers::getFunctionNameWithNamespace($phpcsFile, $functionPtr);
+			$refArgs = $this->getPassByReferenceFunction($functionName);
+			if (! $refArgs) {
+				return false;
+			}
 		}
 
 		$argPtrs = Helpers::findFunctionCallArguments($phpcsFile, $stackPtr);


### PR DESCRIPTION
This PR modifies the system that looks for pass-by-reference functions so that it will accept namespaced functions. This allows including things like `\My\Namespace\doSomething:1` in `sitePassByRefFunctions`.

One thing to note: even with this change, if you list `function_name:1` (without a namespace), it will still match `\My\Namespace\function_name()`. Changing this behavior would be a breaking change and I'm not sure it's even a good idea since the function may be aliased (eg; `use \My\Namespace\function_name`).

Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/349