### PR TITLE
Update for phpcs 4.0.0

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -5,7 +5,7 @@ on:
   # Prevent the build from running when there are only irrelevant changes.
   push:
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
@@ -18,11 +18,11 @@ concurrency:
 
 jobs:
   checkcs:
-    name: 'Basic CS and QA checks'
+    name: "Basic CS and QA checks"
     runs-on: ubuntu-latest
 
     env:
-      XMLLINT_INDENT: '    '
+      XMLLINT_INDENT: "    "
 
     steps:
       - name: Checkout code
@@ -31,13 +31,13 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 'latest'
+          php-version: "latest"
           coverage: none
           tools: cs2pr
 
       # Using PHPCS `master` as an early detection system for bugs upstream.
-      - name: 'Composer: adjust dependencies'
-        run: composer require --no-update squizlabs/php_codesniffer:"dev-master"
+      - name: "Composer: adjust dependencies"
+        run: composer require --no-update squizlabs/php_codesniffer:"4.x-dev"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,40 +34,60 @@ jobs:
         # - PHP 8.4 needs PHPCS 3.11.0+ to run without errors (though the errors don't affect this package).
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3']
-        phpcs_version: ['3.5.6', 'dev-master']
+        php: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]
+        phpcs_version: ["3.5.6", "4.0.0", "4.x-dev"]
+
+        exclude:
+          # PHPCS 4.x requires PHP 7.2+
+          - php: "5.5"
+            phpcs_version: "4.0.0"
+          - php: "5.5"
+            phpcs_version: "4.x-dev"
+          - php: "5.6"
+            phpcs_version: "4.0.0"
+          - php: "5.6"
+            phpcs_version: "4.x-dev"
+          - php: "7.0"
+            phpcs_version: "4.0.0"
+          - php: "7.0"
+            phpcs_version: "4.x-dev"
+          - php: "7.1"
+            phpcs_version: "4.0.0"
+          - php: "7.1"
+            phpcs_version: "4.x-dev"
 
         include:
-          # Make the matrix complete without duplicating builds run in code coverage.
-          - php: '8.4'
-            phpcs_version: '3.6.1'
+          - php: "8.4"
+            phpcs_version: "4.0.0"
+          - php: "8.4"
+            phpcs_version: "3.6.1"
 
-          - php: '8.3'
-            phpcs_version: 'dev-master'
-          - php: '8.3'
-            phpcs_version: '3.6.1'
+          - php: "8.3"
+            phpcs_version: "4.x-dev"
+          - php: "8.3"
+            phpcs_version: "3.6.1"
 
-          - php: '8.2'
-            phpcs_version: 'dev-master'
-          - php: '8.2'
-            phpcs_version: '3.6.1'
+          - php: "8.2"
+            phpcs_version: "4.x-dev"
+          - php: "8.2"
+            phpcs_version: "3.6.1"
 
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-          - php: '8.1'
-            phpcs_version: '3.6.1'
+          - php: "8.1"
+            phpcs_version: "4.x-dev"
+          - php: "8.1"
+            phpcs_version: "3.6.1"
 
-          - php: '8.0'
-            phpcs_version: 'dev-master'
-          - php: '8.0'
-            phpcs_version: '3.5.7'
+          - php: "8.0"
+            phpcs_version: "4.x-dev"
+          - php: "8.0"
+            phpcs_version: "3.5.7"
 
-          - php: '7.4'
-            phpcs_version: 'dev-master'
+          - php: "7.4"
+            phpcs_version: "4.x-dev"
 
           # Experimental builds.
-          - php: '8.5' # Nightly.
-            phpcs_version: 'dev-master'
+          - php: "8.5" # Nightly.
+            phpcs_version: "4.x-dev"
 
     name: "Test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
@@ -82,7 +102,7 @@ jobs:
         run: |
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ matrix.phpcs_version }}" != "4.x-dev" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
@@ -95,7 +115,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: adjust dependencies'
+      - name: "Composer: adjust dependencies"
         run: |
           # Remove dev dependencies which are not compatible with all supported PHP versions.
           composer remove --dev --no-update sirbrillig/phpcs-import-detection phpstan/phpstan
@@ -146,15 +166,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '8.4'
-            phpcs_version: 'dev-master'
-          - php: '7.4'
-            phpcs_version: '3.5.6'
+          - php: "8.4"
+            phpcs_version: "4.x-dev"
+          - php: "7.4"
+            phpcs_version: "3.5.6"
 
-          - php: '5.4'
-            phpcs_version: 'dev-master'
-          - php: '5.4'
-            phpcs_version: '3.5.6'
+          - php: "7.2"
+            phpcs_version: "4.x-dev"
+          - php: "5.4"
+            phpcs_version: "3.5.6"
 
     name: "Coverage: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
@@ -167,7 +187,7 @@ jobs:
         run: |
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ matrix.phpcs_version }}" != "4.x-dev" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
@@ -180,7 +200,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
-      - name: 'Composer: adjust dependencies'
+      - name: "Composer: adjust dependencies"
         run: |
           # Remove dev dependencies which are not compatible with all supported PHP/PHPCS versions.
           composer remove --dev --no-update phpcsstandards/phpcsdevcs sirbrillig/phpcs-import-detection phpstan/phpstan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]
-        phpcs_version: ["3.5.6", "4.0.0", "4.x-dev"]
+        phpcs_version: ["3.5.7", "4.0.0", "4.x-dev"]
 
         exclude:
           # PHPCS 4.x requires PHP 7.2+
@@ -169,12 +169,12 @@ jobs:
           - php: "8.4"
             phpcs_version: "4.x-dev"
           - php: "7.4"
-            phpcs_version: "3.5.6"
+            phpcs_version: "3.5.7"
 
           - php: "7.2"
             phpcs_version: "4.x-dev"
           - php: "5.4"
-            phpcs_version: "3.5.6"
+            phpcs_version: "3.5.7"
 
     name: "Coverage: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -322,16 +322,12 @@ class Helpers
 			if (is_int($functionPtr)) {
 				$functionTokenCode = $tokens[$functionPtr]['code'];
 				// In PHPCS 4.x, function names can be T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, or T_NAME_RELATIVE
-				$validFunctionTokens = [T_STRING];
-				if (defined('T_NAME_FULLY_QUALIFIED')) {
-					$validFunctionTokens[] = T_NAME_FULLY_QUALIFIED;
-				}
-				if (defined('T_NAME_QUALIFIED')) {
-					$validFunctionTokens[] = T_NAME_QUALIFIED;
-				}
-				if (defined('T_NAME_RELATIVE')) {
-					$validFunctionTokens[] = T_NAME_RELATIVE;
-				}
+				$validFunctionTokens = [
+					T_STRING,
+					T_NAME_FULLY_QUALIFIED,
+					T_NAME_QUALIFIED,
+					T_NAME_RELATIVE,
+				];
 				if (in_array($functionTokenCode, $validFunctionTokens, true)) {
 					return $functionPtr;
 				}
@@ -560,17 +556,10 @@ class Helpers
 			T_DOUBLE_QUOTED_STRING,
 			T_HEREDOC,
 			T_STRING,
+			T_NAME_FULLY_QUALIFIED,
+			T_NAME_QUALIFIED,
+			T_NAME_RELATIVE,
 		];
-		// In PHPCS 4.x, function names can be T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, or T_NAME_RELATIVE
-		if (defined('T_NAME_FULLY_QUALIFIED')) {
-			$allowedTypes[] = T_NAME_FULLY_QUALIFIED;
-		}
-		if (defined('T_NAME_QUALIFIED')) {
-			$allowedTypes[] = T_NAME_QUALIFIED;
-		}
-		if (defined('T_NAME_RELATIVE')) {
-			$allowedTypes[] = T_NAME_RELATIVE;
-		}
 		if (! in_array($tokens[$stackPtr]['code'], $allowedTypes, true)) {
 			throw new \Exception("Cannot find variable scope for non-variable {$tokens[$stackPtr]['type']}");
 		}
@@ -1705,28 +1694,25 @@ class Helpers
 
 		// In PHPCS 4.x, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, and T_NAME_RELATIVE
 		// tokens already contain the full namespaced name, so we can return early.
-		if (defined('T_NAME_FULLY_QUALIFIED') && $tokens[$stackPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
+		if ($tokens[$stackPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
 			return $functionName;
 		}
-		if (defined('T_NAME_QUALIFIED') && $tokens[$stackPtr]['code'] === T_NAME_QUALIFIED) {
+		if ($tokens[$stackPtr]['code'] === T_NAME_QUALIFIED) {
 			return $functionName;
 		}
-		if (defined('T_NAME_RELATIVE') && $tokens[$stackPtr]['code'] === T_NAME_RELATIVE) {
+		if ($tokens[$stackPtr]['code'] === T_NAME_RELATIVE) {
 			return $functionName;
 		}
 
 		// Move backwards from the token, collecting namespace separators and
 		// strings, until we encounter whitespace or something else.
-		$partOfNamespace = [T_NS_SEPARATOR, T_STRING];
-		if (defined('T_NAME_QUALIFIED')) {
-			$partOfNamespace[] = T_NAME_QUALIFIED;
-		}
-		if (defined('T_NAME_RELATIVE')) {
-			$partOfNamespace[] = T_NAME_RELATIVE;
-		}
-		if (defined('T_NAME_FULLY_QUALIFIED')) {
-			$partOfNamespace[] = T_NAME_FULLY_QUALIFIED;
-		}
+		$partOfNamespace = [
+			T_NS_SEPARATOR,
+			T_STRING,
+			T_NAME_QUALIFIED,
+			T_NAME_RELATIVE,
+			T_NAME_FULLY_QUALIFIED,
+		];
 		for ($i = $stackPtr - 1; $i > $startOfScope; $i--) {
 			if (! in_array($tokens[$i]['code'], $partOfNamespace, true)) {
 				break;
@@ -1751,13 +1737,13 @@ class Helpers
 		if ($token['code'] === 'PHPCS_T_NULLABLE') {
 			return true;
 		}
-		if (defined('T_NAME_QUALIFIED') && $token['code'] === T_NAME_QUALIFIED) {
+		if ($token['code'] === T_NAME_QUALIFIED) {
 			return true;
 		}
-		if (defined('T_NAME_RELATIVE') && $token['code'] === T_NAME_RELATIVE) {
+		if ($token['code'] === T_NAME_RELATIVE) {
 			return true;
 		}
-		if (defined('T_NAME_FULLY_QUALIFIED') && $token['code'] === T_NAME_FULLY_QUALIFIED) {
+		if ($token['code'] === T_NAME_FULLY_QUALIFIED) {
 			return true;
 		}
 		if ($token['code'] === T_NS_SEPARATOR) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -93,7 +93,7 @@ class Helpers
 		$tokens = $phpcsFile->getTokens();
 		if (isset($tokens[$stackPtr]['nested_parenthesis'])) {
 			/**
-			 * @var array<int|string|null>
+			 * @var list<int|string>
 			 */
 			$openPtrs = array_keys($tokens[$stackPtr]['nested_parenthesis']);
 			return (int)end($openPtrs);
@@ -319,8 +319,22 @@ class Helpers
 		if (is_int($openPtr)) {
 			// First non-whitespace thing and see if it's a T_STRING function name
 			$functionPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $openPtr - 1, null, true, null, true);
-			if (is_int($functionPtr) && $tokens[$functionPtr]['code'] === T_STRING) {
-				return $functionPtr;
+			if (is_int($functionPtr)) {
+				$functionTokenCode = $tokens[$functionPtr]['code'];
+				// In PHPCS 4.x, function names can be T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, or T_NAME_RELATIVE
+				$validFunctionTokens = [T_STRING];
+				if (defined('T_NAME_FULLY_QUALIFIED')) {
+					$validFunctionTokens[] = T_NAME_FULLY_QUALIFIED;
+				}
+				if (defined('T_NAME_QUALIFIED')) {
+					$validFunctionTokens[] = T_NAME_QUALIFIED;
+				}
+				if (defined('T_NAME_RELATIVE')) {
+					$validFunctionTokens[] = T_NAME_RELATIVE;
+				}
+				if (in_array($functionTokenCode, $validFunctionTokens, true)) {
+					return $functionPtr;
+				}
 			}
 		}
 		return null;
@@ -364,9 +378,6 @@ class Helpers
 			if (self::findContainingOpeningBracket($phpcsFile, $nextPtr) === $openPtr) {
 				// Comma is at our level of brackets, it's an argument delimiter.
 				$range = range($lastArgComma + 1, $nextPtr - 1);
-				$range = array_filter($range, function ($element) {
-					return is_int($element);
-				});
 				array_push($argPtrs, $range);
 				$lastArgComma = $nextPtr;
 			}
@@ -394,7 +405,8 @@ class Helpers
 
 		// Is the next non-whitespace an assignment?
 		$nextPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-		if (is_int($nextPtr)
+		if (
+			is_int($nextPtr)
 			&& isset(Tokens::$assignmentTokens[$tokens[$nextPtr]['code']])
 			// Ignore double arrow to prevent triggering on `foreach ( $array as $k => $v )`.
 			&& $tokens[$nextPtr]['code'] !== T_DOUBLE_ARROW
@@ -549,6 +561,16 @@ class Helpers
 			T_HEREDOC,
 			T_STRING,
 		];
+		// In PHPCS 4.x, function names can be T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, or T_NAME_RELATIVE
+		if (defined('T_NAME_FULLY_QUALIFIED')) {
+			$allowedTypes[] = T_NAME_FULLY_QUALIFIED;
+		}
+		if (defined('T_NAME_QUALIFIED')) {
+			$allowedTypes[] = T_NAME_QUALIFIED;
+		}
+		if (defined('T_NAME_RELATIVE')) {
+			$allowedTypes[] = T_NAME_RELATIVE;
+		}
 		if (! in_array($tokens[$stackPtr]['code'], $allowedTypes, true)) {
 			throw new \Exception("Cannot find variable scope for non-variable {$tokens[$stackPtr]['type']}");
 		}
@@ -1290,7 +1312,7 @@ class Helpers
 			return null;
 		}
 		/**
-		 * @var array<int|string|null>
+		 * @var list<int|string>
 		 */
 		$startingParenthesis = array_keys($token['nested_parenthesis']);
 		$startOfArguments = end($startingParenthesis);
@@ -1681,9 +1703,30 @@ class Helpers
 		$startOfScope = self::findVariableScope($phpcsFile, $stackPtr);
 		$functionName = $tokens[$stackPtr]['content'];
 
+		// In PHPCS 4.x, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, and T_NAME_RELATIVE
+		// tokens already contain the full namespaced name, so we can return early.
+		if (defined('T_NAME_FULLY_QUALIFIED') && $tokens[$stackPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
+			return $functionName;
+		}
+		if (defined('T_NAME_QUALIFIED') && $tokens[$stackPtr]['code'] === T_NAME_QUALIFIED) {
+			return $functionName;
+		}
+		if (defined('T_NAME_RELATIVE') && $tokens[$stackPtr]['code'] === T_NAME_RELATIVE) {
+			return $functionName;
+		}
+
 		// Move backwards from the token, collecting namespace separators and
 		// strings, until we encounter whitespace or something else.
 		$partOfNamespace = [T_NS_SEPARATOR, T_STRING];
+		if (defined('T_NAME_QUALIFIED')) {
+			$partOfNamespace[] = T_NAME_QUALIFIED;
+		}
+		if (defined('T_NAME_RELATIVE')) {
+			$partOfNamespace[] = T_NAME_RELATIVE;
+		}
+		if (defined('T_NAME_FULLY_QUALIFIED')) {
+			$partOfNamespace[] = T_NAME_FULLY_QUALIFIED;
+		}
 		for ($i = $stackPtr - 1; $i > $startOfScope; $i--) {
 			if (! in_array($tokens[$i]['code'], $partOfNamespace, true)) {
 				break;
@@ -1706,6 +1749,15 @@ class Helpers
 		$tokens = $phpcsFile->getTokens();
 		$token = $tokens[$stackPtr];
 		if ($token['code'] === 'PHPCS_T_NULLABLE') {
+			return true;
+		}
+		if (defined('T_NAME_QUALIFIED') && $token['code'] === T_NAME_QUALIFIED) {
+			return true;
+		}
+		if (defined('T_NAME_RELATIVE') && $token['code'] === T_NAME_RELATIVE) {
+			return true;
+		}
+		if (defined('T_NAME_FULLY_QUALIFIED') && $token['code'] === T_NAME_FULLY_QUALIFIED) {
 			return true;
 		}
 		if ($token['code'] === T_NS_SEPARATOR) {

--- a/VariableAnalysis/Lib/Helpers.php
+++ b/VariableAnalysis/Lib/Helpers.php
@@ -632,24 +632,6 @@ class Helpers
 	/**
 	 * @param File $phpcsFile
 	 * @param int  $stackPtr
-	 *
-	 * @return bool
-	 */
-	public static function isTokenInsideArrowFunctionDefinition(File $phpcsFile, $stackPtr)
-	{
-		$tokens = $phpcsFile->getTokens();
-		$token = $tokens[$stackPtr];
-		$openParenIndices = isset($token['nested_parenthesis']) ? $token['nested_parenthesis'] : [];
-		if (empty($openParenIndices)) {
-			return false;
-		}
-		$openParenPtr = $openParenIndices[0];
-		return self::isArrowFunction($phpcsFile, $openParenPtr - 1);
-	}
-
-	/**
-	 * @param File $phpcsFile
-	 * @param int  $stackPtr
 	 * @param int  $enclosingScopeIndex
 	 *
 	 * @return ?int

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1508,17 +1508,17 @@ class VariableAnalysisSniff implements Sniff
 		// tokens contain the full namespaced name. Extract just the base name for the
 		// first check so that 'my_function' in the config can match '\My\Namespace\my_function'.
 		$functionBaseName = $functionName;
-		if (defined('T_NAME_FULLY_QUALIFIED') && $tokens[$functionPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
+		if ($tokens[$functionPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
 			$lastBackslashPos = strrpos($functionName, '\\');
 			if ($lastBackslashPos !== false) {
 				$functionBaseName = substr($functionName, $lastBackslashPos + 1);
 			}
-		} elseif (defined('T_NAME_QUALIFIED') && $tokens[$functionPtr]['code'] === T_NAME_QUALIFIED) {
+		} elseif ($tokens[$functionPtr]['code'] === T_NAME_QUALIFIED) {
 			$lastBackslashPos = strrpos($functionName, '\\');
 			if ($lastBackslashPos !== false) {
 				$functionBaseName = substr($functionName, $lastBackslashPos + 1);
 			}
-		} elseif (defined('T_NAME_RELATIVE') && $tokens[$functionPtr]['code'] === T_NAME_RELATIVE) {
+		} elseif ($tokens[$functionPtr]['code'] === T_NAME_RELATIVE) {
 			$lastBackslashPos = strrpos($functionName, '\\');
 			if ($lastBackslashPos !== false) {
 				$functionBaseName = substr($functionName, $lastBackslashPos + 1);

--- a/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -1503,7 +1503,34 @@ class VariableAnalysisSniff implements Sniff
 
 		// Is our function a known pass-by-reference function?
 		$functionName = $tokens[$functionPtr]['content'];
-		$refArgs = $this->getPassByReferenceFunction($functionName);
+
+		// In PHPCS 4.x, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, and T_NAME_RELATIVE
+		// tokens contain the full namespaced name. Extract just the base name for the
+		// first check so that 'my_function' in the config can match '\My\Namespace\my_function'.
+		$functionBaseName = $functionName;
+		if (defined('T_NAME_FULLY_QUALIFIED') && $tokens[$functionPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
+			$lastBackslashPos = strrpos($functionName, '\\');
+			if ($lastBackslashPos !== false) {
+				$functionBaseName = substr($functionName, $lastBackslashPos + 1);
+			}
+		} elseif (defined('T_NAME_QUALIFIED') && $tokens[$functionPtr]['code'] === T_NAME_QUALIFIED) {
+			$lastBackslashPos = strrpos($functionName, '\\');
+			if ($lastBackslashPos !== false) {
+				$functionBaseName = substr($functionName, $lastBackslashPos + 1);
+			}
+		} elseif (defined('T_NAME_RELATIVE') && $tokens[$functionPtr]['code'] === T_NAME_RELATIVE) {
+			$lastBackslashPos = strrpos($functionName, '\\');
+			if ($lastBackslashPos !== false) {
+				$functionBaseName = substr($functionName, $lastBackslashPos + 1);
+			}
+		}
+
+		// Ensure we have a string (should always be true, but helps static analyzers).
+		if (! is_string($functionBaseName) || $functionBaseName === '') {
+			return false;
+		}
+
+		$refArgs = $this->getPassByReferenceFunction($functionBaseName);
 		if (! $refArgs) {
 			// Check again with the fully namespaced function name.
 			$functionName = Helpers::getFunctionNameWithNamespace($phpcsFile, $functionPtr);

--- a/composer.json
+++ b/composer.json
@@ -51,13 +51,12 @@
 	},
 	"require": {
 		"php": ">=5.4.0",
-		"squizlabs/php_codesniffer": "^3.5.6"
+		"squizlabs/php_codesniffer": "^3.5.6 || ^4.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
-		"phpcsstandards/phpcsdevcs": "^1.1",
-		"phpstan/phpstan": "^1.7",
+		"phpstan/phpstan": "^1.7 || ^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
-		"vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
+		"vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0 || ^6.0 || ^7.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 	},
 	"require": {
 		"php": ">=5.4.0",
-		"squizlabs/php_codesniffer": "^3.5.6 || ^4.0.0"
+		"squizlabs/php_codesniffer": "^3.5.7 || ^4.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,33 +30,26 @@
 
     <!--
     #############################################################################
-    USE THE PHPCSDev, VariableAnalysis RULESETS
+    USE THE PSR12, VariableAnalysis RULESETS
     #############################################################################
     -->
 
     <!-- Set minimum PHP version supported to PHP 5.4. -->
     <config name="testVersion" value="5.4-"/>
 
-    <rule ref="PHPCSDev">
+    <rule ref="PSR12">
         <!-- This code base uses tab indentation instead of spaces. -->
         <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
 
-        <!-- Don't enforce lining up the assignment operators in assignment blocks. -->
-        <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning"/>
-
-        <!-- Don't enforce lining up the double arrows in array declarations.
-             Possibly enforce this later once the sniff has been replaced by a better, more configurable version. -->
-        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
-
-        <!-- Don't enforce documentation (yet). -->
-        <exclude name="Generic.Commenting.DocComment"/>
-        <exclude name="PEAR.Commenting.ClassComment"/>
-        <exclude name="PEAR.Commenting.FileComment"/>
-        <exclude name="PEAR.Commenting.InlineComment"/>
-
         <!-- WIP: This is part of PSR12 and should probably be enforced,
              but the codebase needs work before it can be enabled. -->
-        <exclude name="Generic.Files.LineLength.TooLong" />
+        <exclude name="Generic.Files.LineLength"/>
+
+        <!-- Disable excessive function spacing requirements -->
+        <exclude name="Squiz.WhiteSpace.FunctionSpacing"/>
+
+        <!-- Project supports PHP 5.4+ which doesn't have constant visibility -->
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
     </rule>
 
     <rule ref="VariableAnalysis"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+  <file src="VariableAnalysis/Lib/EnumInfo.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$enumIndex]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="VariableAnalysis/Lib/ForLoopInfo.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$conditionEnd]]></code>
+      <code><![CDATA[$conditionStart]]></code>
+      <code><![CDATA[$forIndex]]></code>
+      <code><![CDATA[$initEnd]]></code>
+      <code><![CDATA[$initStart]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="VariableAnalysis/Lib/Helpers.php">
+    <InvalidArgument>
+      <code><![CDATA[$closePtr]]></code>
+    </InvalidArgument>
+    <InvalidOperand>
+      <code><![CDATA[$closePtr]]></code>
+    </InvalidOperand>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$varName]]></code>
+      <code><![CDATA[$varName]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$message]]></code>
+    </PossiblyInvalidOperand>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[isTokenInsideArrowFunctionDefinition]]></code>
+    </PossiblyUnusedMethod>
+    <UnusedVariable>
+      <code><![CDATA[$isNestedAssignment]]></code>
+    </UnusedVariable>
+  </file>
+  <file src="VariableAnalysis/Lib/VariableInfo.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$typeHint]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="VariableAnalysis/Sniffs/CodeAnalysis/VariableAnalysisSniff.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function process(File $phpcsFile, $stackPtr)]]></code>
+      <code><![CDATA[public function register()]]></code>
+    </MissingOverrideAttribute>
+    <UnusedClass>
+      <code><![CDATA[VariableAnalysisSniff]]></code>
+    </UnusedClass>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -28,9 +28,6 @@
     <PossiblyInvalidOperand>
       <code><![CDATA[$message]]></code>
     </PossiblyInvalidOperand>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[isTokenInsideArrowFunctionDefinition]]></code>
-    </PossiblyUnusedMethod>
     <UnusedVariable>
       <code><![CDATA[$isNestedAssignment]]></code>
     </UnusedVariable>

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="VariableAnalysis" />


### PR DESCRIPTION
Fixes https://github.com/sirbrillig/phpcs-variable-analysis/issues/355

This PR follows the upgrade guide in https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Version-4.0-Developer-Upgrade-Guide

The main change is supporting the `T_NAME...` constants like `T_NAME_FULLY_QUALIFIED` in function names.