### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         # - PHP 8.2 needs PHPCS 3.6.1+ to run without errors.
         # - PHP 8.3 needs PHPCS 3.8.0+ to run without errors (though the errors don't affect this package).
         # - PHP 8.4 needs PHPCS 3.11.0+ to run without errors (though the errors don't affect this package).
+        # - PHP 8.5 needs PHPCS 3.13.4+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]
@@ -57,8 +58,13 @@ jobs:
             phpcs_version: "4.x-dev"
 
         include:
-          - php: "8.4"
+          - php: "8.5"
             phpcs_version: "4.0.0"
+          - php: "8.5"
+            phpcs_version: "3.13.4"
+
+          - php: "8.4"
+            phpcs_version: "4.x-dev"
           - php: "8.4"
             phpcs_version: "3.6.1"
 
@@ -86,12 +92,12 @@ jobs:
             phpcs_version: "4.x-dev"
 
           # Experimental builds.
-          - php: "8.5" # Nightly.
+          - php: "8.6" # Nightly.
             phpcs_version: "4.x-dev"
 
     name: "Test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
 
     steps:
       - name: Checkout code
@@ -124,19 +130,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.5' }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v3"
         with:
+          # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.5' }}
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: --ignore-platform-req=php
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Grab PHPUnit version
@@ -166,7 +165,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: "8.4"
+          - php: "8.5"
             phpcs_version: "4.x-dev"
           - php: "7.4"
             phpcs_version: "3.5.7"


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.